### PR TITLE
feat(padding): Set configurable padding (and separators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ let bufferline.semantic_letters = v:true
 let bufferline.letters = 
   \ 'asdfjkl;ghnmxcbziowerutyqpASDFJKLGHNMXCBZIOWERUTYQP'
 
-" Sets the padding width with which to surround each tab
-let bufferline.padding = 4
+" Sets the maximum padding width with which to surround each tab
+let bufferline.maximum_padding = 4
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ let bufferline.semantic_letters = v:true
 let bufferline.letters = 
   \ 'asdfjkl;ghnmxcbziowerutyqpASDFJKLGHNMXCBZIOWERUTYQP'
 
+" Sets the padding width with which to surround each tab
+let bufferline.padding = 4
+
 ```
 
 ## About

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -131,12 +131,12 @@ Here are the groups that you should define if you'd like to style Barbar.
         let g:bufferline.clickable = v:true
 <
 
-					           *g:bufferline.padding*
-`g:bufferline.padding`		        int	(default 4)
+					           *g:bufferline.maximum_padding*
+`g:bufferline.maximum_padding`		int	(default 4)
 
-	Sets the padding width with which to surround each tab
+	Sets the maximum padding width with which to surround each tab
 >
-        let g:bufferline.padding = 4
+        let g:bufferline.maximum_padding = 4
 <
 
 

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -131,5 +131,13 @@ Here are the groups that you should define if you'd like to style Barbar.
         let g:bufferline.clickable = v:true
 <
 
+					           *g:bufferline.padding*
+`g:bufferline.padding`		        int	(default 4)
+
+	Sets the padding width with which to surround each tab
+>
+        let g:bufferline.padding = 4
+<
+
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -53,7 +53,7 @@ let bufferline = extend({
 \ 'closable': v:true,
 \ 'semantic_letters': v:true,
 \ 'clickable': v:true,
-\ 'padding': 4,
+\ 'maximum_padding': 4,
 \ 'letters': 'asdfjkl;ghnmxcbziowerutyqpASDFJKLGHNMXCBZIOWERUTYQP',
 \}, get(g:, 'bufferline', {}))
 
@@ -180,7 +180,7 @@ function! bufferline#render()
    let remaining_width = available_width - used_width
    let remaining_width_per_buffer = remaining_width / buffers_length
    let remaining_padding_per_buffer = remaining_width_per_buffer / 2
-   let padding_width = min([remaining_padding_per_buffer, g:bufferline.padding]) - 1
+   let padding_width = min([remaining_padding_per_buffer, g:bufferline.maximum_padding]) - 1
    let actual_width = used_width + padding_width * buffers_length
 
    let result = ''

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -53,6 +53,7 @@ let bufferline = extend({
 \ 'closable': v:true,
 \ 'semantic_letters': v:true,
 \ 'clickable': v:true,
+\ 'padding': 4,
 \ 'letters': 'asdfjkl;ghnmxcbziowerutyqpASDFJKLGHNMXCBZIOWERUTYQP',
 \}, get(g:, 'bufferline', {}))
 
@@ -94,11 +95,11 @@ let s:buffers = []
 let s:is_picking_buffer = v:false
 
 " Default icons
-let g:icons = extend(get(g:, 'icons', {}), {
+let g:icons = extend({
 \ 'bufferline_default_file': '',
 \ 'bufferline_separator_active':   '▎',
 \ 'bufferline_separator_inactive': '▎',
-\})
+\}, get(g:, 'icons', {}))
 
 
 "===================================
@@ -172,14 +173,13 @@ function! bufferline#render()
    let has_close = g:bufferline.closable
    let buffers_length = len(buffer_numbers)
 
-   let MAX_PADDING = 4
    let base_width = 1 + (has_icons ? 2 : 0) + (has_close ? 2 : 0) " separator + icon + space-after-icon + space-after-name
    let available_width = &columns
    let used_width = s:calculate_used_width(buffer_names, base_width)
    let remaining_width = available_width - used_width
    let remaining_width_per_buffer = remaining_width / buffers_length
    let remaining_padding_per_buffer = remaining_width_per_buffer / 2
-   let padding_width = min([remaining_padding_per_buffer, MAX_PADDING]) - 1
+   let padding_width = min([remaining_padding_per_buffer, g:bufferline.padding]) - 1
    let actual_width = used_width + padding_width * buffers_length
 
    let result = ''


### PR DESCRIPTION
Hi,

I'm working with fairly narrow terminals at the minute - I love the bar, but I don't really want four spaces either side of the tab name.

This PR is just to make that value configurable (in the `g:bufferline` object).

If you don't want folks messing around with your configuration object, feel free to reject this.


Also, in the same way that you're using `extend()` to make the `bufferline` object configurable [here](https://github.com/romgrk/barbar.nvim/blob/master/plugin/bufferline.vim#L50). I thought it would be nice to make to the `g:icons` object configurable in the same way [here](https://github.com/BodneyC/barbar.nvim/blob/master/plugin/bufferline.vim#L102); at the minute, `g:icons` is just overridden.