### PR TITLE
Use tabpagenr instead of nvim api func

### DIFF
--- a/autoload/bufferline/tabpages.vim
+++ b/autoload/bufferline/tabpages.vim
@@ -28,6 +28,8 @@ function! bufferline#tabpages#render()
 
   let current = tabpagenr()
 
+	call getchar()
+
   let result = '%=%#TabLineSel# ' . current . '/' . last . ' '
 
   return result

--- a/autoload/bufferline/tabpages.vim
+++ b/autoload/bufferline/tabpages.vim
@@ -28,8 +28,6 @@ function! bufferline#tabpages#render()
 
   let current = tabpagenr()
 
-	call getchar()
-
   let result = '%=%#TabLineSel# ' . current . '/' . last . ' '
 
   return result

--- a/autoload/bufferline/tabpages.vim
+++ b/autoload/bufferline/tabpages.vim
@@ -10,7 +10,7 @@ function! bufferline#tabpages#width()
     return 0
   end
 
-  let current = nvim_get_current_tabpage()
+  let current = tabpagenr()
 
   return 2 + len(string(current)) + len(string(last))
 endfunc
@@ -26,7 +26,7 @@ function! bufferline#tabpages#render()
     return ''
   end
 
-  let current = nvim_get_current_tabpage()
+  let current = tabpagenr()
 
   let result = '%=%#TabLineSel# ' . current . '/' . last . ' '
 

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -10,7 +10,7 @@ local utils = require'bufferline.utils'
 local len = utils.len
 
 local function calculate_tabpages_width(state)
-  local current = nvim.get_current_tabpage()
+  local current = vim.fn.tabpagenr()
   local total   = vim.fn.tabpagenr('$')
   if not vim.g.bufferline.tabpages or total == 1 then
     return 0

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -155,7 +155,7 @@ local function render()
       close = icon .. ' '
 
       if click_enabled then
-        closePrefix = 
+        closePrefix =
             '%' .. buffer_number .. '@BufferlineCloseClickHandler@' .. closePrefix
       end
     end
@@ -239,7 +239,7 @@ local function render()
     result = result .. separatorPrefix .. separator
   end
 
-  local current_tabpage = nvim.get_current_tabpage()
+  local current_tabpage = vim.fn.tabpagenr()
   local total_tabpages  = vim.fn.tabpagenr('$')
   if layout.tabpages_width > 0 then
     result = result .. '%=%#BufferTabpages# ' .. tostring(current_tabpage) .. '/' .. tostring(total_tabpages) .. ' '


### PR DESCRIPTION
The `nvim_get_current_tabpage` function reports incorrect counts tab pages. Using `tabpagenr()` reports correctly as discovered by @Melkster [here](https://github.com/romgrk/barbar.nvim/issues/22#issuecomment-727072619), so I adjusted the usages.

Tested on my machine to validate.