### PR TITLE
Add separate highlight group for tabpage spacer

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ let bufferline.semantic_letters = v:true
 " New buffer letters are assigned in this order. This order is
 " optimal for the qwerty keyboard layout but might need adjustement
 " for other layouts.
-let bufferline.letters = 
+let bufferline.letters =
   \ 'asdfjkl;ghnmxcbziowerutyqpASDFJKLGHNMXCBZIOWERUTYQP'
 
 " Sets the maximum padding width with which to surround each tab
@@ -174,7 +174,7 @@ let bufferline.maximum_padding = 4
 
 ### Highlighting
 
-For the highligh groups, here are the default ones. Your colorscheme
+For the highlight groups, here are the default ones. Your colorscheme
 can override them by defining them.
 
 ```vim
@@ -212,6 +212,8 @@ function bufferline#highlight#setup()
    \ ['BufferInactiveMod',    fg_modified, bg_inactive],
    \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],
    \ ['BufferInactiveTarget', fg_target,   bg_inactive,  'bold'],
+   \ ['BufferTabpages',       fg_special,  bg_inactive, 'bold'],
+   \ ['BufferTabpageFill',    fg_inactive, bg_inactive],
    \ ])
 endfunc
 ```
@@ -231,5 +233,5 @@ No, barbar has nothing to do with barbarians.
 
 ## License
 
-barbar.nvim: Distributed under the terms of the JSON license.  
-bbye.vim: Distributed under the terms of the GNU Affero license.  
+barbar.nvim: Distributed under the terms of the JSON license.
+bbye.vim: Distributed under the terms of the GNU Affero license.

--- a/autoload/bufferline/highlight.vim
+++ b/autoload/bufferline/highlight.vim
@@ -43,7 +43,7 @@ function! s:fg(groups, default)
    for group in a:groups
       let hl = nvim_get_hl_by_name(group,   1)
       if has_key(hl, 'foreground')
-         return printf("#%x", hl.foreground)
+         return printf("#%06x", hl.foreground)
       end
    endfor
    return a:default
@@ -53,7 +53,7 @@ function! s:bg(groups, default)
    for group in a:groups
       let hl = nvim_get_hl_by_name(group,   1)
       if has_key(hl, 'background')
-         return printf("#%x", hl.background)
+         return printf("#%06x", hl.background)
       end
    endfor
    return a:default

--- a/autoload/bufferline/highlight.vim
+++ b/autoload/bufferline/highlight.vim
@@ -36,6 +36,7 @@ function bufferline#highlight#setup()
    \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],
    \ ['BufferInactiveTarget', fg_target,   bg_inactive,  'bold'],
    \ ['BufferTabpages',       fg_special,  bg_inactive, 'bold'],
+   \ ['BufferTabpageFill',    fg_inactive, bg_inactive],
    \ ])
 endfunc
 

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -103,6 +103,8 @@ Here are the groups that you should define if you'd like to style Barbar.
       \ ['BufferInactiveMod',    fg_modified, bg_inactive],
       \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],
       \ ['BufferInactiveTarget', fg_target,   bg_inactive,  'bold'],
+      \ ['BufferTabpages',       fg_special,  bg_inactive, 'bold'],
+      \ ['BufferTabpageFill',    fg_inactive, bg_inactive],
       \ ])
    endfunc
 <
@@ -143,7 +145,7 @@ Here are the groups that you should define if you'd like to style Barbar.
 	optimal for the qwerty keyboard layout but might need adjustement
 	for other layouts.
 >
-        let g:bufferline.letters = 
+        let g:bufferline.letters =
 	  \ 'asdfjkl;ghnmxcbziowerutyqpASDFJKLGHNMXCBZIOWERUTYQP'
 <
 

--- a/lua/bufferline/get-icon.lua
+++ b/lua/bufferline/get-icon.lua
@@ -5,7 +5,13 @@
 local nvim = require'bufferline.nvim'
 local status, web = pcall(require, 'nvim-web-devicons')
 
-local function get_icon(buffer_name, filetype)
+local function get_attr(group, attr)
+  local rgb_val = (nvim.get_hl_by_name(group, true) or {})[attr]
+
+  return rgb_val and string.format('#%06x', rgb_val) or 'NONE'
+end
+
+local function get_icon(buffer_name, filetype, buffer_status)
   if status == false then
     nvim.command('echohl WarningMsg')
     nvim.command('echom "barbar: bufferline.icons is set to v:true but \\\"nvim-dev-icons\\\" was not found."')
@@ -26,7 +32,17 @@ local function get_icon(buffer_name, filetype)
     extension = vim.fn.matchstr(basename, [[\v\.@<=\w+$]], '', '')
   end
 
-  return web.get_icon(basename, extension, { default = true })
+  local iconChar, iconHl = web.get_icon(basename, extension, { default = true })
+
+  if iconHl and vim.fn.hlexists(iconHl..buffer_status) < 1 then
+    nvim.command(
+      'hi! ' .. iconHl .. buffer_status ..
+      ' guifg=' .. get_attr(iconHl, 'foreground') ..
+      ' guibg=' .. get_attr('Buffer'..buffer_status, 'background')
+    )
+  end
+
+  return iconChar, iconHl..buffer_status
 end
 
 return get_icon

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -137,8 +137,8 @@ local function render()
         iconPrefix = ''
         icon = number_text .. (#number_text > 1 and '' or ' ')
       else
-        local iconChar, iconHl = get_icon(buffer_name, vim.fn.getbufvar(buffer_number, '&filetype'))
-        iconPrefix = status == 'Inactive' and hl('BufferInactive') or hl(iconHl or ('Buffer' .. status))
+        local iconChar, iconHl = get_icon(buffer_name, vim.fn.getbufvar(buffer_number, '&filetype'), status)
+        iconPrefix = hl(status ~= 'Inactive' and iconHl or 'BufferInactive')
         icon = iconChar .. ' '
       end
     end
@@ -234,9 +234,7 @@ local function render()
   result = result .. '%0@BufferlineMainClickHandler@'
 
   if layout.actual_width + 1 <= layout.buffers_width and len(items) > 0 then
-    local separatorPrefix = hl('BufferInactiveSign')
-    local separator = icons.bufferline_separator_inactive
-    result = result .. separatorPrefix .. separator
+    result = result .. hl('BufferTabpageFill') .. icons.bufferline_separator_inactive
   end
 
   local current_tabpage = vim.fn.tabpagenr()

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -67,8 +67,8 @@ local function slice_groups_left(groups, width)
   return result
 end
 
-local function render()
-  local buffer_numbers = state.get_updated_buffers()
+local function render(update_names)
+  local buffer_numbers = state.get_updated_buffers(update_names)
   local current = vim.fn.bufnr('%')
 
   -- Store current buffer to open new ones next to this one
@@ -256,8 +256,8 @@ local function render()
   return result
 end
 
-local function render_safe()
-  local ok, result = pcall(render)
+local function render_safe(update_names)
+  local ok, result = pcall(render, update_names)
   return {ok, tostring(result)}
 end
 

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -233,7 +233,7 @@ function m.update_names()
   end
 end
 
-function m.get_updated_buffers()
+function m.get_updated_buffers(update_names)
   local current_buffers = vim.fn['bufferline#filter']('&buflisted')
   local new_buffers =
     filter(
@@ -270,7 +270,7 @@ function m.get_updated_buffers()
   m.buffers =
     filter(function(b) return nvim.buf_is_valid(b) end, m.buffers)
 
-  if did_change then
+  if did_change or update_names then
     m.update_names()
   end
 

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -25,6 +25,7 @@ function! bufferline#enable()
       augroup bufferline_update
          au!
          au BufNew                 * call bufferline#update()
+         au BufNewFile             * call bufferline#update(v:true)
          au BufEnter               * call bufferline#update()
          au BufWipeout             * call bufferline#update()
          au BufWinEnter            * call bufferline#update()
@@ -121,8 +122,8 @@ let s:last_tabline = ''
 " Section: Main functions
 "========================
 
-function! bufferline#update()
-   let new_value = bufferline#render()
+function! bufferline#update(...)
+   let new_value = bufferline#render(a:0 > 0 ? a:1 : v:false)
    if new_value == s:last_tabline
       return
    end
@@ -130,12 +131,12 @@ function! bufferline#update()
    let s:last_tabline = new_value
 endfu
 
-function! bufferline#update_async()
-   call timer_start(1, {->bufferline#update()})
+function! bufferline#update_async(...)
+   call timer_start(1, {->bufferline#update(a:0 > 0 ? a:1 : v:false)})
 endfu
 
-function! bufferline#render() abort
-   let result = luaeval("require'bufferline.render'.render_safe()")
+function! bufferline#render(update_names) abort
+   let result = luaeval("require'bufferline.render'.render_safe(_A)", a:update_names)
 
    if result[0]
       return result[1]


### PR DESCRIPTION
I added the highlight group `BufferTabpageFill` to define the space between buffers and the tabpage count.

Here's a screenshot:

![BufferTabpageSpacer](https://user-images.githubusercontent.com/36409591/99163038-42c31180-26d2-11eb-994b-8039642da254.png)

Closes #57.

___

Edit: Since the scope of the PR has increased, here is a list of things that have been adjusted:

* Match background of `DevIcon*` highlight groups to `Buffer<status>` groups.
* Add `BufferTabpageFill` for customization of the space between `BufferTabpages` and `Buffer<status>`
* `autocmd BufNewFile` to update names of buffers.
* `printf()` command fix for transforming RGB→Hex color codes using `nvim_get_hl_by_name()`.
* Document changes.

I think that's everything but if I missed something let me know.