### PR TITLE
Allow BufferNext/BufferPrevious to use count

### DIFF
--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -310,6 +310,8 @@ local function goto_buffer (number)
   local idx
   if number == -1 then
     idx = len(m.buffers)
+  elseif number > len(m.buffers) then
+    return
   else
     idx = number
   end

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -317,7 +317,7 @@ local function goto_buffer (number)
   nvim.command('silent buffer ' .. m.buffers[idx])
 end
 
-local function goto_buffer_relative (direction)
+local function goto_buffer_relative(steps)
   m.get_updated_buffers()
 
   local current = vim.fn.bufnr('%')
@@ -348,12 +348,8 @@ local function goto_buffer_relative (direction)
   if idx == nil then
     print("Couldn't find buffer " .. current .. " in the list: " .. vim.inspect(m.buffers))
     return
-  elseif idx == 1 and direction == -1 then
-    idx = len(m.buffers)
-  elseif idx == len(m.buffers) and direction == 1 then
-    idx = 1
   else
-    idx = idx + direction
+    idx = (idx + steps - 1) % len(m.buffers) + 1 -- Lua is indexed from 1
   end
 
   nvim.command('silent buffer ' .. m.buffers[idx])

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -59,8 +59,8 @@ call bufferline#enable()
 command!                BarbarEnable           call bufferline#enable()
 command!                BarbarDisable          call bufferline#disable()
 
-command!          -bang BufferNext             call s:goto_buffer_relative(+1)
-command!          -bang BufferPrevious         call s:goto_buffer_relative(-1)
+command! -count   -bang BufferNext             call s:goto_buffer_relative(v:count1)
+command! -count   -bang BufferPrevious         call s:goto_buffer_relative(-v:count1)
 
 command! -nargs=1 -bang BufferGoto             call s:goto_buffer(<f-args>)
 command!          -bang BufferLast             call s:goto_buffer(-1)
@@ -230,18 +230,17 @@ endfunction
 
 " Buffer movement
 
-function! s:move_current_buffer (direction)
+function! s:move_current_buffer(direction)
    call luaeval("require'bufferline.state'.move_current_buffer(_A)", a:direction)
 endfunc
 
-function! s:goto_buffer (number)
+function! s:goto_buffer(number)
    call luaeval("require'bufferline.state'.goto_buffer(_A)", a:number)
 endfunc
 
-function! s:goto_buffer_relative (direction)
-   call luaeval("require'bufferline.state'.goto_buffer_relative(_A)", a:direction)
+function! s:goto_buffer_relative(steps)
+   call luaeval("require'bufferline.state'.goto_buffer_relative(_A)", a:steps)
 endfunc
-
 
 " Final setup
 


### PR DESCRIPTION
Modify `:BufferNext`/`:BufferPrevious` to use a count to determine the number of steps to jump to get to the next/previous buffer. Defaults to 1/-1.

For instance with the recommended mappings `<A-.>` and `<A-,>` for `:BufferNext`/`:BufferPrevious` one could for example do `3<A-.>` to jump to the third next buffer. If the count to `BufferNext` exceeds the total number of buffers it wraps around and keeps counting from the first buffer as one would expect, and vice versa for `BufferPrevious`.
