### PR TITLE
fix: BufferGoto throws error

### DIFF
--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -310,6 +310,8 @@ local function goto_buffer (number)
   local idx
   if number == -1 then
     idx = len(m.buffers)
+  elseif number > len(m.buffers) then
+    return
   else
     idx = number
   end


### PR DESCRIPTION
Currently when for instance doing `:BufferGoto 5` with only four buffers Vim throws an error. Now Vim will be silent instead.
