### PR TITLE
Add icon highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ let bufferline.auto_hide = v:false
 " if set to 'both', will show buffer index and icons in the tabline
 let bufferline.icons = v:true
 
+" If set, the icon color will follow its corresponding buffer highlight group
+" (see Highlighting below). Otherwise, it will take its default value as defined
+" by kyazdani42/nvim-web-devicons.
+let bufferline.icon_custom_colors = v:false
+
 " Configure icons on the bufferline.
 let bufferline.icon_separator_active = '▎'
 let bufferline.icon_separator_inactive = '▎'
@@ -211,6 +216,8 @@ let bg_inactive = s:bg(['TabLineFill', 'StatusLine'], '#000000')
 "     *Current: current buffer
 "     *Visible: visible but not current buffer
 "    *Inactive: invisible but not current buffer
+"        *Icon: filetype icon
+"       *Index: buffer index
 "         *Mod: when modified
 "        *Sign: the separator between buffers
 "      *Target: letter in buffer-picking mode
@@ -220,14 +227,20 @@ let bg_inactive = s:bg(['TabLineFill', 'StatusLine'], '#000000')
 
 call s:hi_all([
 \ ['BufferCurrent',        fg_current,  bg_current],
+\ ['BufferCurrentIcon',    fg_current,  bg_current],
+\ ['BufferCurrentIndex',   fg_special,  bg_current],
 \ ['BufferCurrentMod',     fg_modified, bg_current],
 \ ['BufferCurrentSign',    fg_special,  bg_current],
 \ ['BufferCurrentTarget',  fg_target,   bg_current,   'bold'],
 \ ['BufferVisible',        fg_visible,  bg_visible],
+\ ['BufferVisibleIcon',    fg_visible,  bg_visible],
+\ ['BufferVisibleIndex',   fg_visible,  bg_visible],
 \ ['BufferVisibleMod',     fg_modified, bg_visible],
 \ ['BufferVisibleSign',    fg_visible,  bg_visible],
 \ ['BufferVisibleTarget',  fg_target,   bg_visible,   'bold'],
 \ ['BufferInactive',       fg_inactive, bg_inactive],
+\ ['BufferInactiveIcon',   fg_inactive, bg_inactive],
+\ ['BufferInactiveIndex',  fg_subtle,   bg_inactive],
 \ ['BufferInactiveMod',    fg_modified, bg_inactive],
 \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],
 \ ['BufferInactiveTarget', fg_target,   bg_inactive,  'bold'],

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ let bufferline.auto_hide = v:false
 " if set to 'both', will show buffer index and icons in the tabline
 let bufferline.icons = v:true
 
-" If set, the icon color will follow its corresponding buffer highlight group
-" (see Highlighting below). Otherwise, it will take its default value as defined
-" by kyazdani42/nvim-web-devicons.
+" If set, the icon color will follow its corresponding buffer
+" highlight group. By default, the Buffer*Icon group is linked to the
+" Buffer* group (see Highlighting below). Otherwise, it will take its
+" default value as defined by devicons.
 let bufferline.icon_custom_colors = v:false
 
 " Configure icons on the bufferline.
@@ -227,19 +228,16 @@ let bg_inactive = s:bg(['TabLineFill', 'StatusLine'], '#000000')
 
 call s:hi_all([
 \ ['BufferCurrent',        fg_current,  bg_current],
-\ ['BufferCurrentIcon',    fg_current,  bg_current],
 \ ['BufferCurrentIndex',   fg_special,  bg_current],
 \ ['BufferCurrentMod',     fg_modified, bg_current],
 \ ['BufferCurrentSign',    fg_special,  bg_current],
 \ ['BufferCurrentTarget',  fg_target,   bg_current,   'bold'],
 \ ['BufferVisible',        fg_visible,  bg_visible],
-\ ['BufferVisibleIcon',    fg_visible,  bg_visible],
 \ ['BufferVisibleIndex',   fg_visible,  bg_visible],
 \ ['BufferVisibleMod',     fg_modified, bg_visible],
 \ ['BufferVisibleSign',    fg_visible,  bg_visible],
 \ ['BufferVisibleTarget',  fg_target,   bg_visible,   'bold'],
 \ ['BufferInactive',       fg_inactive, bg_inactive],
-\ ['BufferInactiveIcon',   fg_inactive, bg_inactive],
 \ ['BufferInactiveIndex',  fg_subtle,   bg_inactive],
 \ ['BufferInactiveMod',    fg_modified, bg_inactive],
 \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],
@@ -248,9 +246,15 @@ call s:hi_all([
 \ ['BufferTabpageFill',    fg_inactive, bg_inactive],
 \ ])
 
-" NOTE: this is an example taken from the source, implementation
-" of s:fg(), s:bg() and s:hi_all() is left as an exercice for the
-" reader.
+call s:hi_link([
+\ ['BufferCurrentIcon',  'BufferCurrent'],
+\ ['BufferVisibleIcon',  'BufferVisible'],
+\ ['BufferInactiveIcon', 'BufferInactive'],
+\ ])
+
+" NOTE: this is an example taken from the source, implementation of
+" s:fg(), s:bg(), s:hi_all() and s:hi_link() is left as an exercise
+" for the reader.
 ```
 
 [See code for the example above](https://github.com/romgrk/barbar.nvim/blob/master/autoload/bufferline/highlight.vim)

--- a/autoload/bufferline/highlight.vim
+++ b/autoload/bufferline/highlight.vim
@@ -19,21 +19,26 @@ function bufferline#highlight#setup()
    "      Current: current buffer
    "      Visible: visible but not current buffer
    "     Inactive: invisible but not current buffer
+   "        -Icon: filetype icon
+   "       -Index: buffer index
    "         -Mod: when modified
    "        -Sign: the separator between buffers
    "      -Target: letter in buffer-picking mode
    call s:hi_all([
    \ ['BufferCurrent',        fg_current,  bg_current],
+   \ ['BufferCurrentIcon',    fg_current,  bg_current],
    \ ['BufferCurrentIndex',   fg_special,  bg_current],
    \ ['BufferCurrentMod',     fg_modified, bg_current],
    \ ['BufferCurrentSign',    fg_special,  bg_current],
    \ ['BufferCurrentTarget',  fg_target,   bg_current,   'bold'],
    \ ['BufferVisible',        fg_visible,  bg_visible],
+   \ ['BufferVisibleIcon',    fg_visible,  bg_visible],
    \ ['BufferVisibleIndex',   fg_visible,  bg_visible],
    \ ['BufferVisibleMod',     fg_modified, bg_visible],
    \ ['BufferVisibleSign',    fg_visible,  bg_visible],
    \ ['BufferVisibleTarget',  fg_target,   bg_visible,   'bold'],
    \ ['BufferInactive',       fg_inactive, bg_inactive],
+   \ ['BufferInactiveIcon',   fg_inactive, bg_inactive],
    \ ['BufferInactiveIndex',  fg_subtle,   bg_inactive],
    \ ['BufferInactiveMod',    fg_modified, bg_inactive],
    \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],

--- a/autoload/bufferline/highlight.vim
+++ b/autoload/bufferline/highlight.vim
@@ -26,25 +26,28 @@ function bufferline#highlight#setup()
    "      -Target: letter in buffer-picking mode
    call s:hi_all([
    \ ['BufferCurrent',        fg_current,  bg_current],
-   \ ['BufferCurrentIcon',    fg_current,  bg_current],
    \ ['BufferCurrentIndex',   fg_special,  bg_current],
    \ ['BufferCurrentMod',     fg_modified, bg_current],
    \ ['BufferCurrentSign',    fg_special,  bg_current],
    \ ['BufferCurrentTarget',  fg_target,   bg_current,   'bold'],
    \ ['BufferVisible',        fg_visible,  bg_visible],
-   \ ['BufferVisibleIcon',    fg_visible,  bg_visible],
    \ ['BufferVisibleIndex',   fg_visible,  bg_visible],
    \ ['BufferVisibleMod',     fg_modified, bg_visible],
    \ ['BufferVisibleSign',    fg_visible,  bg_visible],
    \ ['BufferVisibleTarget',  fg_target,   bg_visible,   'bold'],
    \ ['BufferInactive',       fg_inactive, bg_inactive],
-   \ ['BufferInactiveIcon',   fg_inactive, bg_inactive],
    \ ['BufferInactiveIndex',  fg_subtle,   bg_inactive],
    \ ['BufferInactiveMod',    fg_modified, bg_inactive],
    \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],
    \ ['BufferInactiveTarget', fg_target,   bg_inactive,  'bold'],
    \ ['BufferTabpages',       fg_special,  bg_inactive, 'bold'],
    \ ['BufferTabpageFill',    fg_inactive, bg_inactive],
+   \ ])
+
+   call s:hi_link([
+   \ ['BufferCurrentIcon',  'BufferCurrent'],
+   \ ['BufferVisibleIcon',  'BufferVisible'],
+   \ ['BufferInactiveIcon', 'BufferInactive'],
    \ ])
 
    lua require'bufferline.icons'.set_highlights()
@@ -73,6 +76,12 @@ endfunc
 function! s:hi_all(groups)
    for group in a:groups
       call call(function('s:hi'), group)
+   endfor
+endfunc
+
+function! s:hi_link(pairs)
+   for pair in a:pairs
+      execute 'hi default link ' . join(pair)
    endfor
 endfunc
 

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -90,6 +90,8 @@ Here are the groups that you should define if you'd like to style Barbar.
    "     *Current: current buffer
    "     *Visible: visible but not current buffer
    "    *Inactive: invisible but not current buffer
+   "        *Icon: filetype icon
+   "       *Index: buffer index
    "         *Mod: when modified
    "        *Sign: the separator between buffers
    "      *Target: letter in buffer-picking mode
@@ -99,14 +101,17 @@ Here are the groups that you should define if you'd like to style Barbar.
 
    call s:hi_all([
    \ ['BufferCurrent',        fg_current,  bg_current],
+   \ ['BufferCurrentIndex',   fg_special,  bg_current],
    \ ['BufferCurrentMod',     fg_modified, bg_current],
    \ ['BufferCurrentSign',    fg_special,  bg_current],
    \ ['BufferCurrentTarget',  fg_target,   bg_current,   'bold'],
    \ ['BufferVisible',        fg_visible,  bg_visible],
+   \ ['BufferVisibleIndex',   fg_visible,  bg_visible],
    \ ['BufferVisibleMod',     fg_modified, bg_visible],
    \ ['BufferVisibleSign',    fg_visible,  bg_visible],
    \ ['BufferVisibleTarget',  fg_target,   bg_visible,   'bold'],
    \ ['BufferInactive',       fg_inactive, bg_inactive],
+   \ ['BufferInactiveIndex',  fg_subtle,   bg_inactive],
    \ ['BufferInactiveMod',    fg_modified, bg_inactive],
    \ ['BufferInactiveSign',   fg_subtle,   bg_inactive],
    \ ['BufferInactiveTarget', fg_target,   bg_inactive,  'bold'],
@@ -114,9 +119,15 @@ Here are the groups that you should define if you'd like to style Barbar.
    \ ['BufferTabpageFill',    fg_inactive, bg_inactive],
    \ ])
 
-   " NOTE: this is an example taken from the source, implementation
-   " of s:fg(), s:bg() and s:hi_all() is left as an exercice for the
-   " reader.
+   call s:hi_link([
+   \ ['BufferCurrentIcon',  'BufferCurrent'],
+   \ ['BufferVisibleIcon',  'BufferVisible'],
+   \ ['BufferInactiveIcon', 'BufferInactive'],
+   \ ])
+
+   " NOTE: this is an example taken from the source, implementation of
+   " s:fg(), s:bg(), s:hi_all() and s:hi_link() is left as an exercise
+   " for the reader.
 <
 
 ==============================================================================
@@ -142,6 +153,14 @@ Here are the groups that you should define if you'd like to style Barbar.
 	- If `v:true`, show |devicons| for each buffer's |'filetype'|.
 	- If `"numbers"`, show the buffer number for current buffer.
 	- If `"both"`, show the buffer number and |devicons|.
+
+					   *g:bufferline.icon_custom_colors*
+`g:bufferline.icon_custom_colors`	boolean	(default v:false)
+
+	If set, the icon color will follow its corresponding buffer
+	highlight group. By default, the `Buffer*Icon` group is linked to
+	the `Buffer*` group (see |barbar-highlights|). Otherwise, it will take
+	its default value as defined by |devicons|.
 
 			               *g:bufferline.icon_separator_active*
 `g:bufferline.icon_separator_active`	string (default '▎')

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -101,6 +101,7 @@ local function render(update_names)
   local click_enabled = vim.fn.has('tablineat') and opts.clickable
   local has_close = opts.closable
   local has_icons = (opts.icons == true) or (opts.icons == 'both')
+  local has_icon_custom_colors = opts.icon_custom_colors
   local has_numbers = (opts.icons == 'numbers') or (opts.icons == 'both')
 
   local layout = Layout.calculate(state)
@@ -169,7 +170,7 @@ local function render(update_names)
       if has_icons then
         local iconChar, iconHl = get_icon(buffer_name, vim.fn.getbufvar(buffer_number, '&filetype'), status)
         local hlName = is_inactive and 'BufferInactive' or iconHl
-        iconPrefix = hlName and hl(hlName) or namePrefix
+        iconPrefix = has_icon_custom_colors and hl('Buffer' .. status .. 'Icon') or hlName and hl(hlName) or namePrefix
         icon = iconChar .. ' '
       end
     end

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -98,6 +98,7 @@ let s:DEFAULT_OPTIONS = {
 \ 'icon_separator_active':   '▎',
 \ 'icon_separator_inactive': '▎',
 \ 'icons': v:true,
+\ 'icon_custom_colors': v:false,
 \ 'letters': 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP',
 \ 'maximum_padding': 4,
 \ 'semantic_letters': v:true,


### PR DESCRIPTION
This PR adds the ability to set icon highlight groups. The main purpose is to allow consistent colors across icons. Since this was previously mentioned in #92, I figured others would also be interested in having this as a built-in option.

To enable the icon highlight groups, `icon_custom_colors` has to be set. Since the majority probably want the default web-devicons colors, this option is `false` by default. This should also avoid messing with existing configurations.

I also added the `Index` highlight groups to the README since they appeared to be missing.