### PR TITLE
feat: change default background color to `none` instead of `#000000`

### DIFF
--- a/autoload/bufferline/highlight.vim
+++ b/autoload/bufferline/highlight.vim
@@ -12,9 +12,9 @@ function bufferline#highlight#setup()
    let fg_special  = s:fg(['Special'], '#599eff')
    let fg_subtle   = s:fg(['NonText', 'Comment'], '#555555')
 
-   let bg_current  = s:bg(['Normal'], '#000000')
-   let bg_visible  = s:bg(['TabLineSel', 'Normal'], '#000000')
-   let bg_inactive = s:bg(['TabLineFill', 'StatusLine'], '#000000')
+   let bg_current  = s:bg(['Normal'], 'none')
+   let bg_visible  = s:bg(['TabLineSel', 'Normal'], 'none')
+   let bg_inactive = s:bg(['TabLineFill', 'StatusLine'], 'none')
 
    "      Current: current buffer
    "      Visible: visible but not current buffer


### PR DESCRIPTION
The default bg color is `#000000`, this can look weird, when the background color is set to `NONE` ie. the background is transparent.

This PR changes it to `NONE`. This shouldn't change the current behavior, if a colorscheme sets it to a different value.
See here:
![barbar_black_bg](https://user-images.githubusercontent.com/9267430/116827870-b7fca300-ab9b-11eb-95d5-15332e55f7db.png)
![barbar_black_transparent](https://user-images.githubusercontent.com/9267430/116827873-baf79380-ab9b-11eb-99b7-9f84430cf955.png)
