### PR TITLE
Allow BufferMoveNext/Prev to specify a count

### DIFF
--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -292,23 +292,19 @@ end
 
 -- Movement & tab manipulation
 
-local function move_current_buffer (direction)
+local function move_current_buffer (steps)
   m.get_updated_buffers()
 
   local currentnr = nvim.get_current_buf()
   local idx = utils.index(m.buffers, currentnr)
 
-  if idx == 1 and direction == -1 then
-    return
-  end
-  if idx == len(m.buffers) and direction == 1 then
+  local newidx = math.max(1, math.min(len(m.buffers), idx + steps))
+  if idx == newidx then
     return
   end
 
-  local othernr = m.buffers[idx + direction]
-
-  m.buffers[idx] = othernr
-  m.buffers[idx + direction] = currentnr
+  table.remove(m.buffers, idx)
+  table.insert(m.buffers, newidx, currentnr)
 
   vim.fn['bufferline#update']()
 end

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -61,8 +61,8 @@ command! -count   -bang BufferPrevious         call s:goto_buffer_relative(-v:co
 command! -nargs=1 -bang BufferGoto             call s:goto_buffer(<f-args>)
 command!          -bang BufferLast             call s:goto_buffer(-1)
 
-command!          -bang BufferMoveNext         call s:move_current_buffer(+1)
-command!          -bang BufferMovePrevious     call s:move_current_buffer(-1)
+command! -count   -bang BufferMoveNext         call s:move_current_buffer(v:count1)
+command! -count   -bang BufferMovePrevious     call s:move_current_buffer(-v:count1)
 
 command!          -bang BufferPick             call bufferline#pick_buffer()
 
@@ -217,8 +217,8 @@ endfunction
 
 " Buffer movement
 
-function! s:move_current_buffer(direction)
-   call luaeval("require'bufferline.state'.move_current_buffer(_A)", a:direction)
+function! s:move_current_buffer(steps)
+   call luaeval("require'bufferline.state'.move_current_buffer(_A)", a:steps)
 endfunc
 
 function! s:goto_buffer(number)


### PR DESCRIPTION
Now it matches the behavior of BufferNext and BufferPrev, except it will clamp the position to the start/end instead of wrapping.

The table insert/remove will be slightly less efficient than the element swap, but it shouldn't matter for most cases (<100 buffers open). If performance is a concern I can add a special case to do the element swap if we're only moving it by 1 slot.