### PR TITLE
Feature: 'pinned' buffers similar to chrome tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,18 @@ let bufferline.icon_separator_active = '▎'
 let bufferline.icon_separator_inactive = '▎'
 let bufferline.icon_close_tab = ''
 let bufferline.icon_close_tab_modified = '●'
+let bufferline.icon_pinned = '車'
 
 " Sets the maximum padding width with which to surround each tab.
 let bufferline.maximum_padding = 4
 
 " Sets the maximum buffer name length.
 let bufferline.maximum_length = 30
+
+" Configure the pinned buffer indicator
+" if set to 'icon', will use bufferline.icon_pinned
+" if set to anything else (e.g. '*'), will use that character
+let bufferline.pin_status = 'icon'
 
 " If set, the letters for each buffer in buffer-pick mode will be
 " assigned based on their name. Otherwise or in case all letters are

--- a/README.md
+++ b/README.md
@@ -244,11 +244,6 @@ let bufferline.maximum_padding = 4
 " Sets the maximum buffer name length.
 let bufferline.maximum_length = 30
 
-" Configure the pinned buffer indicator
-" if set to 'icon', will use bufferline.icon_pinned
-" if set to anything else (e.g. '*'), will use that character
-let bufferline.pin_status = 'icon'
-
 " If set, the letters for each buffer in buffer-pick mode will be
 " assigned based on their name. Otherwise or in case all letters are
 " already assigned, the behavior is to assign letters in order of
@@ -309,6 +304,7 @@ vim.g.bufferline = {
   icon_separator_inactive = '▎',
   icon_close_tab = '',
   icon_close_tab_modified = '●',
+  icon_pinned = '車',
 
   -- Sets the maximum padding width with which to surround each tab
   maximum_padding = 1,

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ nnoremap <silent>    <A-6> :BufferGoto 6<CR>
 nnoremap <silent>    <A-7> :BufferGoto 7<CR>
 nnoremap <silent>    <A-8> :BufferGoto 8<CR>
 nnoremap <silent>    <A-9> :BufferLast<CR>
+" Pin/unpin buffer
+nnoremap <silent>    <A-p> :BufferPin<CR>
 " Close buffer
 nnoremap <silent>    <A-c> :BufferClose<CR>
 " Wipeout buffer

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -205,14 +205,6 @@ Here are the groups that you should define if you'd like to style Barbar.
 
 	The icon used to indicate that a buffer is pinned.
 
-			                          *g:bufferline.pin_status*
-`g:bufferline.pin_status`                           string (default 'icon')
-
-        Controls display of the 'pinned' status of a buffer. The default value
-        of 'icon' will use |g:bufferline.icon_pinned| (requires a patched
-        font).  When set to anything else (e.g. '*'), that string will be used
-        to show that a buffer is pinned.
-
 						    *g:bufferline.closable*
 `g:bufferline.closable`		boolean	(default v:true)
 

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -47,7 +47,8 @@ The name of each command should be descriptive enough for you to use it.
    nnoremap <silent>    <A-7> :BufferGoto 7<CR>
    nnoremap <silent>    <A-8> :BufferGoto 8<CR>
    nnoremap <silent>    <A-9> :BufferLast<CR>
-
+   " Pin/unpin buffer
+   nnoremap <silent>    <A-p> :BufferPin<CR>
    " Close buffer
    nnoremap <silent>    <A-c> :BufferClose<CR>
 
@@ -198,6 +199,19 @@ Here are the groups that you should define if you'd like to style Barbar.
 
 	The button used to close the tab when it has been modified since
 	last save.
+
+			                         *g:bufferline.icon_pinned*
+`g:bufferline.icon_pinned`                            string (default '車')
+
+	The icon used to indicate that a buffer is pinned.
+
+			                          *g:bufferline.pin_status*
+`g:bufferline.pin_status`                           string (default 'icon')
+
+        Controls display of the 'pinned' status of a buffer. The default value
+        of 'icon' will use |g:bufferline.icon_pinned| (requires a patched
+        font).  When set to anything else (e.g. '*'), that string will be used
+        to show that a buffer is pinned.
 
 						    *g:bufferline.closable*
 `g:bufferline.closable`		boolean	(default v:true)

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -50,15 +50,9 @@ local function calculate_buffers_width(state, base_width)
       end
 
       if state.is_pinned(buffer_number) then
-        if opts.pin_status == 'icon' then
-          width = width
-            + 1 -- spacing after filename
-            + 2 -- pin icon is 2 characters wide
-        else
-          width = width
-            + 1 -- spacing after filename
-            + strwidth(opts.pin_status)
-        end
+        width = width
+          + 1 -- spacing after filename
+          + strwidth(opts.icon_pinned)
       end
 
       if opts.closable then

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -49,6 +49,18 @@ local function calculate_buffers_width(state, base_width)
           + 1 -- space-after-buffer-index
       end
 
+      if state.is_pinned(buffer_number) then
+        if opts.pin_status == 'icon' then
+          width = width
+            + 1 -- spacing after filename
+            + 2 -- pin icon is 2 characters wide
+        else
+          width = width
+            + 1 -- spacing after filename
+            + strwidth(opts.pin_status)
+        end
+      end
+
       if opts.closable then
         width = width
           + strwidth(not nvim.buf_get_option(buffer_number, 'modified') -- close-icon

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -148,6 +148,10 @@ local function render(update_names)
     local iconPrefix = ''
     local icon = ''
 
+    -- The pin icon
+    local pinPrefix = ''
+    local pin = ''
+
     if has_numbers then
       local number_text = tostring(i)
       bufferIndexPrefix = hl('Buffer' .. status .. 'Index')
@@ -172,6 +176,15 @@ local function render(update_names)
         local hlName = is_inactive and 'BufferInactive' or iconHl
         iconPrefix = has_icon_custom_colors and hl('Buffer' .. status .. 'Icon') or hlName and hl(hlName) or namePrefix
         icon = iconChar .. ' '
+      end
+
+      if state.is_pinned(buffer_number) then
+        pinPrefix = namePrefix
+        if opts.pin_status == 'icon' then
+          pin = ' ' .. icons.pinned
+        else
+          pin = ' ' .. opts.pin_status
+        end
       end
     end
 
@@ -211,6 +224,7 @@ local function render(update_names)
         {iconPrefix,         icon},
         {jumpLetterPrefix,   jumpLetter},
         {namePrefix,         name},
+        {pinPrefix,          pin},
         {'',                 padding},
         {'',                 ' '},
         {closePrefix,        close},

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -180,11 +180,7 @@ local function render(update_names)
 
       if state.is_pinned(buffer_number) then
         pinPrefix = namePrefix
-        if opts.pin_status == 'icon' then
-          pin = ' ' .. icons.pinned
-        else
-          pin = ' ' .. opts.pin_status
-        end
+        pin = ' ' .. icons.pinned
       end
     end
 

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -68,6 +68,7 @@ command! -count   -bang BufferMovePrevious     call s:move_current_buffer(-v:cou
 command! -nargs=1 -bang BufferMove             call s:move_current_buffer_to(<f-args>)
 
 command!          -bang BufferPick             call bufferline#pick_buffer()
+command!                BufferPin              lua require'bufferline.state'.toggle_pin()
 
 command!          -bang BufferOrderByDirectory call bufferline#order_by_directory()
 command!          -bang BufferOrderByLanguage  call bufferline#order_by_language()
@@ -96,6 +97,7 @@ let s:DEFAULT_OPTIONS = {
 \ 'exclude_name': v:null,
 \ 'icon_close_tab': '',
 \ 'icon_close_tab_modified': '●',
+\ 'icon_pinned': '車',
 \ 'icon_separator_active':   '▎',
 \ 'icon_separator_inactive': '▎',
 \ 'icons': v:true,
@@ -104,6 +106,7 @@ let s:DEFAULT_OPTIONS = {
 \ 'maximum_padding': 4,
 \ 'maximum_length': 30,
 \ 'no_name_title': v:null,
+\ 'pin_status': 'icon',
 \ 'semantic_letters': v:true,
 \ 'tabpages': v:true,
 \}

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -106,7 +106,6 @@ let s:DEFAULT_OPTIONS = {
 \ 'maximum_padding': 4,
 \ 'maximum_length': 30,
 \ 'no_name_title': v:null,
-\ 'pin_status': 'icon',
 \ 'semantic_letters': v:true,
 \ 'tabpages': v:true,
 \}


### PR DESCRIPTION
Addresses #84
The mental model is pretty simple:

* Users can "pin" a buffer.
* "pinned" buffers always appear to the left of unpinned buffers

I updated the UI to show the pin status with an icon
![Screenshot from 2021-06-12 10-38-26](https://user-images.githubusercontent.com/506791/121784728-6e27b500-cb6a-11eb-9312-2b19f22c056b.png)
Or without, if the user doesn't have nerd fonts
![Screenshot from 2021-06-12 10-40-22](https://user-images.githubusercontent.com/506791/121784757-a29b7100-cb6a-11eb-9933-49352b0c65d9.png)

Does this seem like a feature that you would want to add to barbar? Does it make sense as is or would you prefer to tweak how it works?

Also there's a small merge conflict with my other PR, so if you like both of them merge the other one first and I'll resolve it here.