### PR TITLE
Integrate with vim-session to save buffer order

### DIFF
--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -20,6 +20,7 @@ function! bufferline#enable()
       au BufWritePost   * call <SID>check_modified()
       au TextChanged    * call <SID>check_modified()
       end
+      au User SessionSavePre lua require'bufferline.state'.on_pre_save()
    augroup END
 
    augroup bufferline_update
@@ -122,6 +123,9 @@ let s:last_tabline = ''
 "========================
 
 function! bufferline#update(...)
+   if get(g:, 'SessionLoad')
+      return
+   endif
    let new_value = bufferline#render(a:0 > 0 ? a:1 : v:false)
    if new_value == s:last_tabline
       return


### PR DESCRIPTION
I noticed that when I save and load sessions the buffers come back in a somewhat arbitrary order. Right now this is just restoring `m.buffers`, and from my tests that seems to work fine. Is there anything else that you think I would need to save/restore from the state while I'm at it, like `buffers_by_id` or possibly `scroll`?