### PR TITLE
Add ordering by window number

### DIFF
--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -539,11 +539,14 @@ local function order_by_language()
 end
 
 local function order_by_window_number()
-  table.sort(m.buffers, function(a, b)
-    local na = bufwinnr(bufname(a))
-    local nb = bufwinnr(bufname(b))
-    return na < nb
-  end)
+  table.sort(
+    m.buffers,
+    with_pin_order(function(a, b)
+      local na = bufwinnr(bufname(a))
+      local nb = bufwinnr(bufname(b))
+      return na < nb
+    end)
+  )
   vim.fn['bufferline#update']()
 end
 

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -14,6 +14,7 @@ local filter = vim.tbl_filter
 local includes = vim.tbl_contains
 local bufname = vim.fn.bufname
 local fnamemodify = vim.fn.fnamemodify
+local bufwinnr = vim.fn.bufwinnr
 
 
 local ANIMATION_OPEN_DURATION  = 150
@@ -537,6 +538,14 @@ local function order_by_language()
   vim.fn["bufferline#update"]()
 end
 
+local function order_by_window_number()
+  table.sort(m.buffers, function(a, b)
+    local na = bufwinnr(bufname(a))
+    local nb = bufwinnr(bufname(b))
+    return na < nb
+  end)
+  vim.fn['bufferline#update']()
+end
 
 -- vim-session integration
 
@@ -615,6 +624,7 @@ m.goto_buffer_relative = goto_buffer_relative
 m.toggle_pin = toggle_pin
 m.order_by_directory = order_by_directory
 m.order_by_language = order_by_language
+m.order_by_window_number = order_by_window_number
 
 m.on_pre_save = on_pre_save
 m.restore_buffers = restore_buffers

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -72,6 +72,7 @@ command!                BufferPin              lua require'bufferline.state'.tog
 
 command!          -bang BufferOrderByDirectory call bufferline#order_by_directory()
 command!          -bang BufferOrderByLanguage  call bufferline#order_by_language()
+command!          -bang BufferOrderByWindowNumber    call bufferline#order_by_window_number()
 
 command! -bang -complete=buffer -nargs=?
                       \ BufferClose            call bufferline#bbye#delete('bdelete', <q-bang>, <q-args>)
@@ -172,6 +173,10 @@ endfunc
 
 function! bufferline#order_by_language()
    call luaeval("require'bufferline.state'.order_by_language()")
+endfunc
+
+function! bufferline#order_by_window_number()
+   call luaeval("require'bufferline.state'.order_by_window_number()")
 endfunc
 
 function! bufferline#close(abuf)


### PR DESCRIPTION
This is useful when the layout changes such that the tabline order no longer matches the window number order (e.g., swapping windows `<c-w><c-r>`).

![barbar2](https://user-images.githubusercontent.com/5385846/124981558-8fa18280-dfea-11eb-8d03-137f87938bbd.gif)

This covers part of what I mentioned in https://github.com/romgrk/barbar.nvim/issues/155.