### PR TITLE
[RFC] Sort buffers by time used

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ vim.g.bufferline = {
   icon_close_tab_modified = '●',
   icon_pinned = '車',
 
+  -- After this long with no activity, consider the user idle
+  -- (used for BufferOrderByTime)
+  idle_timeout = 5,
+
   -- Sets the maximum padding width with which to surround each tab
   maximum_padding = 1,
 
@@ -326,6 +330,10 @@ vim.g.bufferline = {
   -- already assigned, the behavior is to assign letters in order of
   -- usability (see order below)
   semantic_letters = true,
+
+  -- How fast the "time" score for a buffer decays (used for BufferOrderByTime)
+  -- This number is how long it takes for the buffer to lose half its score.
+  time_decay_rate = 10,
 
   -- New buffer letters are assigned in this order. This order is
   -- optimal for the qwerty keyboard layout but might need adjustement

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ nnoremap <silent> <C-s>    :BufferPick<CR>
 " Sort automatically by...
 nnoremap <silent> <Space>bd :BufferOrderByDirectory<CR>
 nnoremap <silent> <Space>bl :BufferOrderByLanguage<CR>
+nnoremap <silent> <Space>bt :BufferOrderByTime<CR>
 
 " Other:
 " :BarbarEnable - enables barbar (enabled by default)
@@ -238,6 +239,10 @@ let bufferline.icon_close_tab = ''
 let bufferline.icon_close_tab_modified = '●'
 let bufferline.icon_pinned = '車'
 
+" After this long with no activity, consider the user idle
+" (used for BufferOrderByTime)
+let bufferline.idle_timeout = 5
+
 " Sets the maximum padding width with which to surround each tab.
 let bufferline.maximum_padding = 4
 
@@ -249,6 +254,10 @@ let bufferline.maximum_length = 30
 " already assigned, the behavior is to assign letters in order of
 " usability (see order below)
 let bufferline.semantic_letters = v:true
+
+" How fast the "time" score for a buffer decays (used for BufferOrderByTime)
+" This number is how long it takes for the buffer to lose half its score.
+let bufferline.time_decay_rate = 10
 
 " New buffer letters are assigned in this order. This order is
 " optimal for the qwerty keyboard layout but might need adjustement

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -243,33 +243,10 @@ local function get_buffer_list()
   local buffers = nvim.list_bufs()
   local result = {}
 
-  local exclude_ft   = opts.exclude_ft
-  local exclude_name = opts.exclude_name
-
   for i, buffer in ipairs(buffers) do
-
-    if not nvim.buf_get_option(buffer, 'buflisted') then
-      goto continue
+    if utils.is_displayed(opts, buffer) then
+      table.insert(result, buffer)
     end
-
-    if exclude_ft ~= vim.NIL then
-      local ft = nvim.buf_get_option(buffer, 'filetype')
-      if utils.has(exclude_ft, ft) then
-        goto continue
-      end
-    end
-
-    if exclude_name ~= vim.NIL then
-      local fullname = nvim.nvim_buf_get_name(buffer)
-      local name = utils.basename(fullname)
-      if utils.has(exclude_name, name) then
-        goto continue
-      end
-    end
-
-    table.insert(result, buffer)
-
-    ::continue::
   end
 
   return result

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -6,6 +6,7 @@ local vim = vim
 local api = vim.api
 local nvim = require'bufferline.nvim'
 local utils = require'bufferline.utils'
+local timing = require'bufferline.timing'
 local Layout = require'bufferline.layout'
 local len = utils.len
 local index = utils.index
@@ -537,6 +538,18 @@ local function order_by_language()
   vim.fn["bufferline#update"]()
 end
 
+local function order_by_time()
+  table.sort(
+    m.buffers,
+    with_pin_order(function(a, b)
+      local a_score = timing.get_score(a)
+      local b_score = timing.get_score(b)
+      return a_score > b_score
+    end)
+  )
+  vim.fn['bufferline#update']()
+end
+
 
 -- vim-session integration
 
@@ -615,6 +628,7 @@ m.goto_buffer_relative = goto_buffer_relative
 m.toggle_pin = toggle_pin
 m.order_by_directory = order_by_directory
 m.order_by_language = order_by_language
+m.order_by_time = order_by_time
 
 m.on_pre_save = on_pre_save
 m.restore_buffers = restore_buffers

--- a/lua/bufferline/timing.lua
+++ b/lua/bufferline/timing.lua
@@ -1,0 +1,90 @@
+local nvim = require("bufferline.nvim")
+local clock = require("bufferline.userclock")
+local active_buffer = -1
+local LAST_DECAY_TIME = "bufferline_last_decay_time"
+local TIME_SCORE = "bufferline_time_score"
+local TIME_ACTIVATED = "bufferline_time_activated"
+
+local function is_listed(bufnr)
+  return nvim.buf_is_valid(bufnr) and nvim.buf_get_option(bufnr, "buflisted")
+end
+
+local function get_last_decay_time(bufnr, now)
+  local ok, val = pcall(nvim.buf_get_var, bufnr, LAST_DECAY_TIME)
+  return ok and val or now
+end
+
+local function get_time_activated(bufnr, now)
+  local ok, val = pcall(nvim.buf_get_var, bufnr, TIME_ACTIVATED)
+  return ok and val or now
+end
+
+local function get_stored_score(bufnr)
+  local ok, val = pcall(nvim.buf_get_var, bufnr, TIME_SCORE)
+  if ok then
+    -- Floats get serialized as a table. See :help lua-special-tbl
+    if type(val) == "table" then
+      return val[vim.val_idx]
+    else
+      return val
+    end
+  else
+    return 0
+  end
+end
+
+local function apply_decay(bufnr, now)
+  local last_time = get_last_decay_time(bufnr, now)
+  local delta = now - last_time
+  local score = get_stored_score(bufnr)
+
+  score = score / 2 ^ (delta / vim.g.bufferline.time_decay_rate)
+  nvim.buf_set_var(bufnr, TIME_SCORE, score)
+  nvim.buf_set_var(bufnr, LAST_DECAY_TIME, now)
+  return score
+end
+
+local function get_score(bufnr)
+  local now = clock.time()
+  if bufnr == active_buffer then
+    local time_activated = get_time_activated(bufnr, now)
+    return get_stored_score(bufnr) + (now - time_activated)
+  else
+    return apply_decay(bufnr, now)
+  end
+end
+
+local function on_leave_buffer()
+  if is_listed(active_buffer) then
+    local now = clock.time()
+    local score = get_stored_score(active_buffer)
+    local time_activated = get_time_activated(active_buffer, now)
+    local delta = now - time_activated
+    nvim.buf_set_var(active_buffer, TIME_SCORE, score + delta)
+    nvim.buf_set_var(active_buffer, LAST_DECAY_TIME, now)
+  end
+  active_buffer = -1
+end
+
+local function set_active_buffer(bufnr)
+  if bufnr ~= active_buffer then
+    on_leave_buffer()
+  end
+
+  if not is_listed(bufnr) or bufnr == active_buffer then
+    return
+  end
+  local now = clock.time()
+  apply_decay(bufnr, now)
+  nvim.buf_set_var(bufnr, TIME_ACTIVATED, now)
+  active_buffer = bufnr
+end
+
+local function on_enter_buf()
+  set_active_buffer(nvim.get_current_buf())
+end
+
+return {
+  get_score = get_score,
+  on_enter_buf = on_enter_buf,
+}

--- a/lua/bufferline/timing.lua
+++ b/lua/bufferline/timing.lua
@@ -1,12 +1,12 @@
-local nvim = require("bufferline.nvim")
-local clock = require("bufferline.userclock")
+local nvim = require'bufferline.nvim'
+local clock = require'bufferline.userclock'
 local active_buffer = -1
-local LAST_DECAY_TIME = "bufferline_last_decay_time"
-local TIME_SCORE = "bufferline_time_score"
-local TIME_ACTIVATED = "bufferline_time_activated"
+local LAST_DECAY_TIME = 'bufferline_last_decay_time'
+local TIME_SCORE = 'bufferline_time_score'
+local TIME_ACTIVATED = 'bufferline_time_activated'
 
 local function is_listed(bufnr)
-  return nvim.buf_is_valid(bufnr) and nvim.buf_get_option(bufnr, "buflisted")
+  return nvim.buf_is_valid(bufnr) and nvim.buf_get_option(bufnr, 'buflisted')
 end
 
 local function get_last_decay_time(bufnr, now)
@@ -23,7 +23,7 @@ local function get_stored_score(bufnr)
   local ok, val = pcall(nvim.buf_get_var, bufnr, TIME_SCORE)
   if ok then
     -- Floats get serialized as a table. See :help lua-special-tbl
-    if type(val) == "table" then
+    if type(val) == 'table' then
       return val[vim.val_idx]
     else
       return val

--- a/lua/bufferline/timing.lua
+++ b/lua/bufferline/timing.lua
@@ -80,11 +80,11 @@ local function set_active_buffer(bufnr)
   active_buffer = bufnr
 end
 
-local function on_enter_buf()
+local function on_enter_buffer()
   set_active_buffer(nvim.get_current_buf())
 end
 
 return {
   get_score = get_score,
-  on_enter_buf = on_enter_buf,
+  on_enter_buffer = on_enter_buffer,
 }

--- a/lua/bufferline/timing.lua
+++ b/lua/bufferline/timing.lua
@@ -1,13 +1,10 @@
 local nvim = require'bufferline.nvim'
 local clock = require'bufferline.userclock'
+local utils = require'bufferline.utils'
 local active_buffer = -1
 local LAST_DECAY_TIME = 'bufferline_last_decay_time'
 local TIME_SCORE = 'bufferline_time_score'
 local TIME_ACTIVATED = 'bufferline_time_activated'
-
-local function is_listed(bufnr)
-  return nvim.buf_is_valid(bufnr) and nvim.buf_get_option(bufnr, 'buflisted')
-end
 
 local function get_last_decay_time(bufnr, now)
   local ok, val = pcall(nvim.buf_get_var, bufnr, LAST_DECAY_TIME)
@@ -55,7 +52,7 @@ local function get_score(bufnr)
 end
 
 local function on_leave_buffer()
-  if is_listed(active_buffer) then
+  if utils.is_displayed(vim.g.bufferline, active_buffer) then
     local now = clock.time()
     local score = get_stored_score(active_buffer)
     local time_activated = get_time_activated(active_buffer, now)
@@ -71,7 +68,8 @@ local function set_active_buffer(bufnr)
     on_leave_buffer()
   end
 
-  if not is_listed(bufnr) or bufnr == active_buffer then
+  local opts = vim.g.bufferline
+  if bufnr == active_buffer or not utils.is_displayed(opts, bufnr) then
     return
   end
   local now = clock.time()

--- a/lua/bufferline/userclock.lua
+++ b/lua/bufferline/userclock.lua
@@ -1,0 +1,23 @@
+-- This is a clock that starts at 0 and will only increment when the user is
+-- active (controlled by calling report_activity()).
+local accum = 0
+local last_activity_start = os.time()
+local active_until = last_activity_start + vim.g.bufferline.idle_timeout
+
+local function report_activity()
+  local now = os.time()
+  if now > active_until then
+    accum = accum + (active_until - last_activity_start)
+    last_activity_start = now
+  end
+  active_until = now + vim.g.bufferline.idle_timeout
+end
+
+local function time()
+  return accum + (math.min(os.time(), active_until) - last_activity_start)
+end
+
+return {
+  report_activity = report_activity,
+  time = time,
+}

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -3,6 +3,7 @@
 --
 
 local vim = vim
+local nvim = require'bufferline.nvim'
 local bufname = vim.fn.bufname
 local fnamemodify = vim.fn.fnamemodify
 local matchlist = vim.fn.matchlist
@@ -126,6 +127,33 @@ local function get_unique_name (first, second)
   return first_result, second_result
 end
 
+local function is_displayed(opts, buffer)
+  local exclude_ft   = opts.exclude_ft
+  local exclude_name = opts.exclude_name
+
+  if not nvim.buf_is_valid(buffer) then
+    return false
+  elseif not nvim.buf_get_option(buffer, 'buflisted') then
+    return false
+  end
+
+  if exclude_ft ~= vim.NIL then
+    local ft = nvim.buf_get_option(buffer, 'filetype')
+    if has(exclude_ft, ft) then
+      return false
+    end
+  end
+
+  if exclude_name ~= vim.NIL then
+    local fullname = nvim.nvim_buf_get_name(buffer)
+    local name = basename(fullname)
+    if has(exclude_name, name) then
+      return false
+    end
+  end
+  return true
+end
+
 -- print(vim.inspect(get_buffer_names(vim.g['bufferline#'].buffers)))
 
 return {
@@ -138,4 +166,5 @@ return {
   basename = basename,
   get_buffer_name = get_buffer_name,
   get_unique_name = get_unique_name,
+  is_displayed = is_displayed,
 }

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -41,7 +41,7 @@ function! bufferline#enable()
    augroup END
 
    augroup bufferline_time
-      au BufEnter               * lua require'bufferline.timing'.on_enter_buf()
+      au BufEnter               * lua require'bufferline.timing'.on_enter_buffer()
       au CursorMoved            * lua require'bufferline.userclock'.report_activity()
       au CursorMovedI           * lua require'bufferline.userclock'.report_activity()
    augroup END

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -40,13 +40,19 @@ function! bufferline#enable()
       au TermOpen               * call bufferline#update_async(v:true, 500)
    augroup END
 
+   augroup bufferline_time
+      au BufEnter               * lua require'bufferline.timing'.on_enter_buf()
+      au CursorMoved            * lua require'bufferline.userclock'.report_activity()
+      au CursorMovedI           * lua require'bufferline.userclock'.report_activity()
+   augroup END
+
    call bufferline#highlight#setup()
    call bufferline#update()
 endfunc
 
 function! bufferline#disable()
    augroup bufferline | au! | augroup END
-   augroup bufferline_update | au! | augroup END
+   augroup bufferline_time | au! | augroup END
    let &tabline = ''
 endfunc
 
@@ -72,6 +78,7 @@ command!                BufferPin              lua require'bufferline.state'.tog
 
 command!          -bang BufferOrderByDirectory call bufferline#order_by_directory()
 command!          -bang BufferOrderByLanguage  call bufferline#order_by_language()
+command!          -bang BufferOrderByTime      call bufferline#order_by_time()
 
 command! -bang -complete=buffer -nargs=?
                       \ BufferClose            call bufferline#bbye#delete('bdelete', <q-bang>, <q-args>)
@@ -102,11 +109,13 @@ let s:DEFAULT_OPTIONS = {
 \ 'icon_separator_inactive': '▎',
 \ 'icons': v:true,
 \ 'icon_custom_colors': v:false,
+\ 'idle_timeout': 5,
 \ 'letters': 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP',
 \ 'maximum_padding': 4,
 \ 'maximum_length': 30,
 \ 'no_name_title': v:null,
 \ 'semantic_letters': v:true,
+\ 'time_decay_rate': 10,
 \ 'tabpages': v:true,
 \}
 
@@ -172,6 +181,10 @@ endfunc
 
 function! bufferline#order_by_language()
    call luaeval("require'bufferline.state'.order_by_language()")
+endfunc
+
+function! bufferline#order_by_time()
+   call luaeval("require'bufferline.state'.order_by_time()")
 endfunc
 
 function! bufferline#close(abuf)

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -41,6 +41,7 @@ function! bufferline#enable()
    augroup END
 
    augroup bufferline_time
+      au!
       au BufEnter               * lua require'bufferline.timing'.on_enter_buffer()
       au CursorMoved            * lua require'bufferline.userclock'.report_activity()
       au CursorMovedI           * lua require'bufferline.userclock'.report_activity()


### PR DESCRIPTION
This is an attempt to add functionality similar to what was requested in #91. The main difference is that instead of scoring each buffer based on the number of times it was entered, we are scoring the buffer based on how long we spent inside of it.

* We use `CursorMoved` and `CursorMovedI` to determine if the user is still active inside of a buffer
* There's an idle timeout so we stop scoring a buffer if the user tabs out of vim, walks away from their keyboard, or falls asleep
* The scores decay over time, so buffers that are used more recently will naturally bubble up to the top
* Re-ordering is handled by `:BufferOrderByTime` to be consistent with the other ordering methods

Looking for feedback around
* Thoughts about this time method vs the frequency method mentioned in the original issue
* The default values for `idle_timeout` and `time_decay_rate`. They've been fine with my initial testing, but want to know if it feels too jumpy to other people.