### PR TITLE
Add BufferCloseAllButPinned command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ nnoremap <silent>    <A-c> :BufferClose<CR>
 "                          :BufferWipeout<CR>
 " Close commands
 "                          :BufferCloseAllButCurrent<CR>
+"                          :BufferCloseAllButPinned<CR>
 "                          :BufferCloseBuffersLeft<CR>
 "                          :BufferCloseBuffersRight<CR>
 " Magic buffer-picking mode

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -56,6 +56,7 @@ The name of each command should be descriptive enough for you to use it.
    "                          :BufferWipeout<CR>
    " Close commands
    "                          :BufferCloseAllButCurrent<CR>
+   "                          :BufferCloseAllButPinned<CR>
    "                          :BufferCloseBuffersLeft<CR>
    "                          :BufferCloseBuffersRight<CR>
 

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -462,6 +462,16 @@ local function close_all_but_current()
   vim.fn['bufferline#update']()
 end
 
+local function close_all_but_pinned()
+  local buffers = m.buffers
+  for i, number in ipairs(buffers) do
+    if not is_pinned(number) then
+      vim.fn['bufferline#bbye#delete']('bdelete', '', bufname(number))
+    end
+  end
+  vim.fn['bufferline#update']()
+end
+
 local function close_buffers_left()
   local idx = index(m.buffers, nvim.get_current_buf()) - 1
   if idx == nil then
@@ -603,6 +613,7 @@ m.set_offset = set_offset
 m.close_buffer = close_buffer
 m.close_buffer_animated = close_buffer_animated
 m.close_all_but_current = close_all_but_current
+m.close_all_but_pinned = close_all_but_pinned
 m.close_buffers_right = close_buffers_right
 m.close_buffers_left = close_buffers_left
 

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -81,6 +81,7 @@ command! -bang -complete=buffer -nargs=?
                       \ BufferWipeout          call bufferline#bbye#delete('bwipeout', <q-bang>, <q-args>)
 
 command!                BufferCloseAllButCurrent   lua require'bufferline.state'.close_all_but_current()
+command!                BufferCloseAllButPinned    lua require'bufferline.state'.close_all_but_pinned()
 command!                BufferCloseBuffersLeft     lua require'bufferline.state'.close_buffers_left()
 command!                BufferCloseBuffersRight    lua require'bufferline.state'.close_buffers_right()
 


### PR DESCRIPTION
As [suggested](https://github.com/romgrk/barbar.nvim/pull/145#issuecomment-891620255) this is the MR to add the ":BufferCloseAllButPinned" functionality.

This command makes use of the new "pin" functionality.
It will close all open buffers but the pinned ones.