### PR TITLE
feat: improve visibility of file names that exceed maximum_length

### DIFF
--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -59,7 +59,15 @@ local function get_name(opts, number)
   end
 
   if len(name) > opts.maximum_length then
-    name = '…' .. slice(name, -opts.maximum_length, -1)
+    local ext_index = string.find(string.reverse(name), '%.')
+    local trimmed_name = string.sub(name, 1, opts.maximum_length - (ext_index or 0))
+
+    if ext_index ~= nil then
+      local extension = string.sub(name, len(name) - ext_index + 1, -1)
+      name =  trimmed_name .. '…' .. extension
+    else
+      name = trimmed_name .. '…'
+    end
   end
 
   return name


### PR DESCRIPTION
Improve how the file name is displayed when it exceeds `maximum_length` from this:
![image](https://user-images.githubusercontent.com/57547764/130402598-0ffcc062-4565-46ca-a469-d761cf66e73d.png)

To this:
![image](https://user-images.githubusercontent.com/57547764/130402687-ca3b0e61-9f31-424f-aadc-55a18999338f.png)

Keeping some of the original name and file type extension for icon support. If the file doesn't have an extension, it's just trimmed.