### PR TITLE
Support ":confirm BufferClose"

### DIFF
--- a/autoload/bufferline/bbye.vim
+++ b/autoload/bufferline/bbye.vim
@@ -23,7 +23,13 @@
 " For the full copy of the GNU Affero General Public License see:
 " http://www.gnu.org/licenses.
 
-function! bufferline#bbye#delete(action, bang, buffer_name)
+function! bufferline#bbye#delete(action, bang, buffer_name, ...)
+    if a:0 == 0
+        let l:mods = ""
+    else
+        let l:mods = a:1
+    endif
+
     let buffer = s:str2bufnr(a:buffer_name)
 
     if buffer < 0
@@ -31,7 +37,7 @@ function! bufferline#bbye#delete(action, bang, buffer_name)
     endif
 
     let is_modified = nvim_buf_get_option(buffer, 'modified')
-    let has_confirm = nvim_get_option('confirm')
+    let has_confirm = nvim_get_option('confirm') || (match(l:mods, 'conf') != -1)
 
     if is_modified && empty(a:bang) && !has_confirm
         let error = "E89: No write since last change for buffer "
@@ -76,7 +82,7 @@ function! bufferline#bbye#delete(action, bang, buffer_name)
     " buffer to still _exist_ even though it won't be :bdelete-able.
     if buflisted(buffer) && buffer != bufnr("%")
         try
-            exe a:action . a:bang . " " . buffer
+            exe l:mods . " " . a:action . a:bang . " " . buffer
         catch /^Vim([^)]*):E516:/ " E516: No buffers were deleted
             " Canceled by `set confirm`
             exe buffer . 'b'

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -76,11 +76,11 @@ command!          -bang BufferOrderByLanguage  call bufferline#order_by_language
 command!          -bang BufferOrderByWindowNumber    call bufferline#order_by_window_number()
 
 command! -bang -complete=buffer -nargs=?
-                      \ BufferClose            call bufferline#bbye#delete('bdelete', <q-bang>, <q-args>)
+                      \ BufferClose            call bufferline#bbye#delete('bdelete', <q-bang>, <q-args>, <q-mods>)
 command! -bang -complete=buffer -nargs=?
-                      \ BufferDelete           call bufferline#bbye#delete('bdelete', <q-bang>, <q-args>)
+                      \ BufferDelete           call bufferline#bbye#delete('bdelete', <q-bang>, <q-args>, <q-mods>)
 command! -bang -complete=buffer -nargs=?
-                      \ BufferWipeout          call bufferline#bbye#delete('bwipeout', <q-bang>, <q-args>)
+                      \ BufferWipeout          call bufferline#bbye#delete('bwipeout', <q-bang>, <q-args>, <q-mods>)
 
 command!                BufferCloseAllButCurrent   lua require'bufferline.state'.close_all_but_current()
 command!                BufferCloseAllButPinned    lua require'bufferline.state'.close_all_but_pinned()


### PR DESCRIPTION
To get Vim to ask you if you want to close a modified buffer, you have to add `set confirm` in your config file.

This allows using `:confirm BufferClose` instead, which is in line with the builtin `:confirm bdelete` method.