### PR TITLE
Fix trimmed name recursion due to exceeding length

### DIFF
--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -58,16 +58,20 @@ local function get_name(opts, number)
     end
   end
 
-  if len(name) > opts.maximum_length then
+  local ellipsis = '…'
+  local max_len = opts.maximum_length
+  if #name > max_len then
     local ext_index = string.find(string.reverse(name), '%.')
-    local trimmed_name = string.sub(name, 1, opts.maximum_length - (ext_index or 0))
 
-    if ext_index ~= nil then
-      local extension = string.sub(name, len(name) - ext_index + 1, -1)
-      name =  trimmed_name .. '…' .. extension
+    if ext_index ~= nil and (ext_index < max_len - #ellipsis) then
+      local extension = string.sub(name, -ext_index)
+      name = string.sub(name, 1, max_len - #ellipsis - #extension) .. ellipsis .. extension
     else
-      name = trimmed_name .. '…'
+      name = string.sub(name, 1, max_len - #ellipsis) .. ellipsis
     end
+
+    -- safety to prevent recursion in any future edge case
+    name = string.sub(name, 1, max_len)
   end
 
   return name


### PR DESCRIPTION
This fixes a bug introduced by #181 which causes an infinite recursion and a crash when a buffer name exceeds the maximum length.

This was detailed in LunarVIM: https://github.com/LunarVim/LunarVim/issues/1636

The error:
![The error](https://user-images.githubusercontent.com/34749972/135150680-10386fc2-0f53-4840-81cf-4fd919b00937.png)

---

A simplified reproduction using the new (fixed) and old (broken) trimmed name code has these results:
``` markdown
# new
ext_index: 83
max_len - ext_index: -53
path 2, invalid extension
name len:  30
trimmed name:  main.lua \$* >> sumneko-lua…
 
name len:  13
trimmed name:  highlight.vim
 
ext_index: 4
max_len - ext_index: 26
valid extension
name len:  30
trimmed name:  super-really-very-long-….vim
 
# old
name len:  121
trimmed name:  main.lua \$* >> sumneko-lua-languag….lua \$* >> sumneko-lua-language-server^@^@  chmod +x sumneko-lua-language-server^@
 
name len:  13
trimmed name:  highlight.vim
 
name len:  33
trimmed name:  super-really-very-long-fil….vim
```

The simplified code: <details>
<summary>Click to expand</summary>

``` lua
local max_len = 30
local fnamemodify = vim.fn.fnamemodify
local function basename(path)
 return fnamemodify(path, ':t')
end

local function trimname(path)
  local name = basename(path)

  local ellipsis = '…'
  if #name > max_len then
    local ext_index = string.find(string.reverse(name), '%.')
    print('ext_index: ' .. ext_index)
    print('max_len - ext_index: ' .. max_len - ext_index)

    if ext_index ~= nil and (ext_index < max_len - #ellipsis) then
      print('valid extension')
      local extension = string.sub(name, -ext_index)
      name = string.sub(name, 1, max_len - #ellipsis - #extension) .. ellipsis .. extension
    else
      print('path 2, invalid extension')
      name = string.sub(name, 1, max_len - #ellipsis) .. ellipsis
    end

    -- safety to prevent recursion in any missing edge case
    name = string.sub(name, 1, max_len)
  end
  print('name len: ', #name)
  print('trimmed name: ', name)
  print(' ')
end

local function old_trimname(path)
  local name = basename(path)
  if #name > max_len then
    local ext_index = string.find(string.reverse(name), '%.')
    local trimmed_name = string.sub(name, 1, max_len - (ext_index or 0))

    if ext_index ~= nil then
      local extension = string.sub(name, #name - ext_index + 1, -1)
      name =  trimmed_name .. '…' .. extension
    else
      name = trimmed_name .. '…'
    end
  end
  print('name len: ', #name)
  print('trimmed name: ', name)
  print(' ')
end

print('# new')
trimname('main.lua \\$* >> sumneko-lua-language-server^@^@  chmod +x sumneko-lua-language-server^@')
trimname('autoload/bufferline/highlight.vim')
trimname('autoload/bufferline/super-really-very-long-filename.vim')

print('# old')
old_trimname('main.lua \\$* >> sumneko-lua-language-server^@^@  chmod +x sumneko-lua-language-server^@')
old_trimname('autoload/bufferline/highlight.vim')
old_trimname('autoload/bufferline/super-really-very-long-filename.vim')
```

</details>