### PR TITLE
Enable use of both buffer_number & icon simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ let bufferline.exclude_name = ['package.json']
 " if set to 'buffer_number', will show buffer number in the tabline
 " if set to 'numbers', will show buffer index in the tabline
 " if set to 'both', will show buffer index and icons in the tabline
-" if set to 'buffer_number', will show buffer number and icons in the tabline
+" if set to 'buffer_number_with_icon', will show buffer number and icons in the tabline
 let bufferline.icons = v:true
 
 " Sets the icon's highlight group.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ let bufferline.exclude_name = ['package.json']
 " if set to 'buffer_number', will show buffer number in the tabline
 " if set to 'numbers', will show buffer index in the tabline
 " if set to 'both', will show buffer index and icons in the tabline
+" if set to 'buffer_number', will show buffer number and icons in the tabline
 let bufferline.icons = v:true
 
 " Sets the icon's highlight group.

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -176,7 +176,7 @@ Here are the groups that you should define if you'd like to style Barbar.
 	- If `"buffer_numbers"`, show the buffer number for current buffer.
 	- If `"numbers"`, show the buffer index for current buffer.
 	- If `"both"`, show the buffer index and |devicons|.
-	- If `"buffer_numbers_with_icons"`, show the buffer number for current buffer and |devicons|.
+	- If `"buffer_number_with_icon"`, show the buffer number for current buffer and |devicons|.
 
 					   *g:bufferline.icon_custom_colors*
 `g:bufferline.icon_custom_colors`	boolean, string (default v:false)

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -176,6 +176,7 @@ Here are the groups that you should define if you'd like to style Barbar.
 	- If `"buffer_numbers"`, show the buffer number for current buffer.
 	- If `"numbers"`, show the buffer index for current buffer.
 	- If `"both"`, show the buffer index and |devicons|.
+	- If `"buffer_numbers_with_icons"`, show the buffer number for current buffer and |devicons|.
 
 					   *g:bufferline.icon_custom_colors*
 `g:bufferline.icon_custom_colors`	boolean, string (default v:false)

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -88,7 +88,7 @@ end
 local function calculate(state)
   local opts = vim.g.bufferline
 
-  local has_icons = (opts.icons == true) or (opts.icons == 'both')
+  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_numbers_with_icons') 
 
   -- [icon + space-after-icon] + space-after-name
   local base_width =

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -88,7 +88,7 @@ end
 local function calculate(state)
   local opts = vim.g.bufferline
 
-  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_numbers_with_icons') 
+  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_number_with_icon') 
 
   -- [icon + space-after-icon] + space-after-name
   local base_width =

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -211,9 +211,9 @@ local function render(update_names)
 
   local click_enabled = has('tablineat') and opts.clickable
   local has_close = opts.closable
-  local has_icons = (opts.icons == true) or (opts.icons == 'both')
+  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_numbers_with_icons')
   local has_icon_custom_colors = opts.icon_custom_colors
-  local has_buffer_number = (opts.icons == 'buffer_numbers')
+  local has_buffer_number = (opts.icons == 'buffer_numbers') or (opts.icons == 'buffer_numbers_with_icons')
   local has_numbers = (opts.icons == 'numbers') or (opts.icons == 'both')
 
   local layout = Layout.calculate(state)

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -211,9 +211,9 @@ local function render(update_names)
 
   local click_enabled = has('tablineat') and opts.clickable
   local has_close = opts.closable
-  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_numbers_with_icons')
+  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_number_with_icon')
   local has_icon_custom_colors = opts.icon_custom_colors
-  local has_buffer_number = (opts.icons == 'buffer_numbers') or (opts.icons == 'buffer_numbers_with_icons')
+  local has_buffer_number = (opts.icons == 'buffer_numbers') or (opts.icons == 'buffer_number_with_icon')
   local has_numbers = (opts.icons == 'numbers') or (opts.icons == 'both')
 
   local layout = Layout.calculate(state)


### PR DESCRIPTION
Hi all,

I didn't see a way of modifying the configuration to allow the use of both  `buffer_number` _and_ `icon` at the same time. This small pull request allows the user to do just that. Probably a small use-case, but it's one I wanted and thought others should have access to as well.

I also believe I updated the documentation in all the appropriate places, but I'm not very familiar with the docs in this projects so I may have missed some. Happy to make corrections as needed.

Cheers,
Jake