### PR TITLE
Fix `close_buffers_right()` and add `:BufferCloseAllButCurrentOrPinned`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ nnoremap <silent>    <A-c> :BufferClose<CR>
 " Close commands
 "                          :BufferCloseAllButCurrent<CR>
 "                          :BufferCloseAllButPinned<CR>
+"                          :BufferCloseAllButCurrentOrPinned<CR>
 "                          :BufferCloseBuffersLeft<CR>
 "                          :BufferCloseBuffersRight<CR>
 " Magic buffer-picking mode

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -57,6 +57,7 @@ The name of each command should be descriptive enough for you to use it.
    " Close commands
    "                          :BufferCloseAllButCurrent<CR>
    "                          :BufferCloseAllButPinned<CR>
+   "                          :BufferCloseAllButCurrentOrPinned<CR>
    "                          :BufferCloseBuffersLeft<CR>
    "                          :BufferCloseBuffersRight<CR>
 

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -608,7 +608,7 @@ local function close_buffers_right()
   if idx == nil then
     return
   end
-  for i = idx, len(m.buffers) do
+  for i = len(m.buffers), idx, -1 do
     vim.fn['bufferline#bbye#delete']('bdelete', '', bufname(m.buffers[i]))
   end
   m.update()

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -592,6 +592,17 @@ local function close_all_but_pinned()
   m.update()
 end
 
+local function close_all_but_current_or_pinned()
+  local buffers = m.buffers
+  local current = nvim.get_current_buf()
+  for i, number in ipairs(buffers) do
+    if not is_pinned(number) and number ~= current then
+      vim.fn['bufferline#bbye#delete']('bdelete', '', bufname(number))
+    end
+  end
+  m.update()
+end
+
 local function close_buffers_left()
   local idx = index_of(m.buffers, nvim.get_current_buf()) - 1
   if idx == nil then
@@ -754,6 +765,7 @@ m.close_buffer = close_buffer
 m.close_buffer_animated = close_buffer_animated
 m.close_all_but_current = close_all_but_current
 m.close_all_but_pinned = close_all_but_pinned
+m.close_all_but_current_or_pinned = close_all_but_current_or_pinned
 m.close_buffers_right = close_buffers_right
 m.close_buffers_left = close_buffers_left
 

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -82,10 +82,11 @@ command! -bang -complete=buffer -nargs=?
 command! -bang -complete=buffer -nargs=?
                       \ BufferWipeout          call bufferline#bbye#delete('bwipeout', <q-bang>, <q-args>, <q-mods>)
 
-command!                BufferCloseAllButCurrent   lua require'bufferline.state'.close_all_but_current()
-command!                BufferCloseAllButPinned    lua require'bufferline.state'.close_all_but_pinned()
-command!                BufferCloseBuffersLeft     lua require'bufferline.state'.close_buffers_left()
-command!                BufferCloseBuffersRight    lua require'bufferline.state'.close_buffers_right()
+command!                BufferCloseAllButCurrent            lua require'bufferline.state'.close_all_but_current()
+command!                BufferCloseAllButPinned             lua require'bufferline.state'.close_all_but_pinned()
+command!                BufferCloseAllButCurrentOrPinned    lua require'bufferline.state'.close_all_but_current_or_pinned()
+command!                BufferCloseBuffersLeft              lua require'bufferline.state'.close_buffers_left()
+command!                BufferCloseBuffersRight             lua require'bufferline.state'.close_buffers_right()
 
 "=================
 " Section: Options


### PR DESCRIPTION
Fix the function `close_buffers_right()` and make the command `:BuffCloseBuffersRight` work (mentioned in issue [#214](https://github.com/romgrk/barbar.nvim/issues/214#issue-1117525872) ).
![图片](https://user-images.githubusercontent.com/76579810/151582297-c169d6a8-c831-45d2-bcbd-902e7d991cc5.png)
