### PR TITLE
Draft: Modified icon without close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ let bufferline.tabpages = v:true
 " Enable/disable close button
 let bufferline.closable = v:true
 
+" Enable/disable modified buffer icon
+let bufferline.show_modified_icon = v:true
+
 " Enables/disable clickable tabs
 "  - left-click: go to buffer
 "  - middle-click: delete buffer

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -225,7 +225,13 @@ Here are the groups that you should define if you'd like to style Barbar.
 						    *g:bufferline.closable*
 `g:bufferline.closable`		boolean	(default v:true)
 
-	Controls if close buttons are shown.
+	Controls if close button is shown when file is not modified.
+
+						    *g:bufferline.show_modified_icon*
+`g:bufferline.show_modified_icon`		boolean	(default v:true)
+
+	Controls if close button is shown as the modified icon
+	when file is modified.
 
 					    *g:bufferline.semantic_letters*
 `g:bufferline.semantic_letters`		boolean	(default v:true)

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -293,18 +293,16 @@ local function render(update_names)
       end
     end
 
+    local trailingIcon =
+      (is_pinned and opts.icon_pinned) or
+      (has_modified and is_modified and opts.icon_close_tab_modified) or
+      (has_close and opts.icon_close_tab)
+
     local closePrefix = ''
     local close = ''
-    if has_close or has_modified or is_pinned then
-      local closeIcon =
-        is_pinned and
-          opts.icon_pinned or
-        (not is_modified and
-          opts.icon_close_tab or
-          opts.icon_close_tab_modified)
-
+    if trailingIcon then
       closePrefix = namePrefix
-      close = closeIcon .. ' '
+      close = trailingIcon .. ' '
 
       if click_enabled then
         closePrefix =

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -211,6 +211,7 @@ local function render(update_names)
 
   local click_enabled = has('tablineat') and opts.clickable
   local has_close = opts.closable
+  local has_modified = opts.show_modified_icon
   local has_icons = (opts.icons == true) or (opts.icons == 'both')
   local has_icon_custom_colors = opts.icon_custom_colors
   local has_buffer_number = (opts.icons == 'buffer_numbers')
@@ -294,7 +295,7 @@ local function render(update_names)
 
     local closePrefix = ''
     local close = ''
-    if has_close or is_pinned then
+    if has_close or has_modified or is_pinned then
       local closeIcon =
         is_pinned and
           opts.icon_pinned or

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -96,6 +96,7 @@ let s:DEFAULT_OPTIONS = {
 \ 'auto_hide': v:false,
 \ 'clickable': v:true,
 \ 'closable': v:true,
+\ 'show_modified_icon': v:true,
 \ 'exclude_ft': v:null,
 \ 'exclude_name': v:null,
 \ 'icon_close_tab': '',


### PR DESCRIPTION
Attempts to solve #217, but still not working perfectly. :slightly_frowning_face:  I guess I need some help.

So, I'm not very experienced with nvim plugins (almost never really looked at the codes), but I'm trying to solve the issue I opened myself, since you said a PR is welcome.

I added a `show_modified_icon` option that is used in some checks to verify if the modified icon should be shown or not.

I also tried to make a way where the close icon would not show if `closeable` is false, but `show_modified_icon` is true (or if the buffer is pinned). What I wanted is to not show the close button, only the modified icon.\
It also works the other way around, so we can have only the close button even if the file is modified by setting `closeable` to **true** and `show_modified_icon` to **false**, if that is desired.

I also made the default value of `show_modified_icon` to be true.

The name of option, `show_modified_icon`, is just an ideia, it could be just `modifiable` to match `closeable`, dunno.

I did not change the name of the option `icon_close_tab_modified`, since that could be a breaking change and people would have to update their config file. At first I thought the name made less sense now, but it does work as a close button when the file is modified, so it is not wrong. In the end I think the name should stay the same. What do you think?

But most importantly, I could **not** make it work correctly yet... Right now, if you set one of the options to false and the other to true, the filenames may overlap. In this example, my changed icon is `[+]`, and it looks like this with `closeable` set to **false** and `show_modified_icon` to **true**:

Unmodified files:

![image](https://user-images.githubusercontent.com/60318892/154825407-de56ae36-7896-421d-8088-ab4996ea2c6d.png)

Modified files:

![image](https://user-images.githubusercontent.com/60318892/154825418-609da755-dfea-4deb-b61f-fd852216a408.png)

It is worth noting that when I move to the second file, it stays on top, hiding some of the first file's name and icons:

![image](https://user-images.githubusercontent.com/60318892/154825749-8b453e92-c81f-4a44-b68f-184b28c1a916.png)

---

And if I set `closeable` to **true** and `show_modifiable_icon` to **false**, the filenames also move a little when the file is modified. In this example, I used ` xxxxx` as my close icon just to show the situation more clearly:

Unmodified files:

![image](https://user-images.githubusercontent.com/60318892/154825535-fa99507a-234b-4715-b0d0-919f380439be.png)

Modified files:

![image](https://user-images.githubusercontent.com/60318892/154825538-2df36148-a6d7-4b43-a566-d4dc1b175324.png)

Current file on top, hiding some of the "x"s:

![image](https://user-images.githubusercontent.com/60318892/154825726-b4d05a4b-f42e-44c6-b626-149ca2c4e455.png)

---

When both options are set to **true**, everything plays out nicely, as far as I could tell

Unmodified files:

![image](https://user-images.githubusercontent.com/60318892/154825710-f9535ea8-4cae-4436-b986-660e45eebd04.png)

Modified files:

![image](https://user-images.githubusercontent.com/60318892/154825713-6359e134-0d9a-4510-b896-2bbed9d80ebc.png)\
![image](https://user-images.githubusercontent.com/60318892/154825797-919f9b37-79a4-4114-a2e0-b6c891940b4a.png)
