### PR TITLE
fix: keyboard interrupt error for buffer pick

### DIFF
--- a/lua/bufferline/jump_mode.lua
+++ b/lua/bufferline/jump_mode.lua
@@ -120,21 +120,25 @@ local function activate()
   nvim.command('redraw')
   state.is_picking_buffer = false
 
-  local char = vim.fn.getchar()
-  local letter = vim.fn.nr2char(char)
+  local ok, char = pcall(vim.fn.getchar)
 
-  local did_switch = false
+  if ok then
+    local letter = vim.fn.nr2char(char)
 
-  if letter ~= '' then
-    if m.buffer_by_letter[letter] ~= nil then
-      local bufnr = m.buffer_by_letter[letter]
-      nvim.command('buffer' .. bufnr)
-      did_switch = true
-    else
-      nvim.command('echohl WarningMsg')
-      nvim.command([[echom "Couldn't find buffer"]])
-      nvim.command('echohl None')
+    if letter ~= '' then
+      if m.buffer_by_letter[letter] ~= nil then
+        local bufnr = m.buffer_by_letter[letter]
+        nvim.command('buffer' .. bufnr)
+      else
+        nvim.command('echohl WarningMsg')
+        nvim.command([[echom "Couldn't find buffer"]])
+        nvim.command('echohl None')
+      end
     end
+  else
+    nvim.command('echohl WarningMsg')
+    nvim.command([[echom "Invalid input"]])
+    nvim.command('echohl None')
   end
 
   state.update()


### PR DESCRIPTION
After activating `buffer pick`, if Ctrl-c is pressed the following error occurs.

```
E5108: Error executing lua Keyboard interrupt                                                                                                                                                                                                               
stack traceback:                                                                                                                                                                                                                                            
        [C]: in function 'getchar'                                                                                                                                                                                                                          
        ...pack/packer/opt/barbar.nvim/lua/bufferline/jump_mode.lua:123: in function 'activate'                                                                                                                                                             
        [string "luaeval()"]:1: in main chunk  
```

Wrapping `vim.fn.getchar` with `pcall` seems fixes the issue.

Also I removed `did_switch_ variable since it seems the variable is not used anywhere.