### PR TITLE
fix: set highlights for both `cterm` and `gui` on startup

### DIFF
--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -7,7 +7,9 @@ return {
   --- Setup the highlight groups for this plugin.
   setup = function()
 
-    local fg_target = 'red'
+    --- @type barbar.util.Highlight
+    local fg_target = {cterm = 'red'}
+    fg_target.gui = fg_target.cterm
 
     local fg_current  = hl.fg_or_default({'Normal'}, '#efefef', 255)
     local fg_visible  = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
@@ -21,8 +23,6 @@ return {
     local bg_visible  = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
     local bg_inactive = hl.bg_or_default({'TabLineFill', 'StatusLine'}, 'none')
 
-    local set_default_hl = hl.get_default_setter()
-
     --      Current: current buffer
     --      Visible: visible but not current buffer
     --     Inactive: invisible but not current buffer
@@ -31,23 +31,23 @@ return {
     --         -Mod: when modified
     --        -Sign: the separator between buffers
     --      -Target: letter in buffer-picking mode
-    set_default_hl('BufferCurrent',        bg_current, fg_current)
-    set_default_hl('BufferCurrentIndex',   bg_current, fg_special)
-    set_default_hl('BufferCurrentMod',     bg_current, fg_modified)
-    set_default_hl('BufferCurrentSign',    bg_current, fg_special)
-    set_default_hl('BufferCurrentTarget',  bg_current, fg_target, true)
-    set_default_hl('BufferInactive',       bg_inactive, fg_inactive)
-    set_default_hl('BufferInactiveIndex',  bg_inactive, fg_subtle)
-    set_default_hl('BufferInactiveMod',    bg_inactive, fg_modified)
-    set_default_hl('BufferInactiveSign',   bg_inactive, fg_subtle)
-    set_default_hl('BufferInactiveTarget', bg_inactive, fg_target, true)
-    set_default_hl('BufferTabpageFill',    bg_inactive, fg_inactive)
-    set_default_hl('BufferTabpages',       bg_inactive, fg_special, true)
-    set_default_hl('BufferVisible',        bg_visible, fg_visible)
-    set_default_hl('BufferVisibleIndex',   bg_visible, fg_visible)
-    set_default_hl('BufferVisibleMod',     bg_visible, fg_modified)
-    set_default_hl('BufferVisibleSign',    bg_visible, fg_visible)
-    set_default_hl('BufferVisibleTarget',  bg_visible, fg_target, true)
+    hl.set_default('BufferCurrent',        bg_current, fg_current)
+    hl.set_default('BufferCurrentIndex',   bg_current, fg_special)
+    hl.set_default('BufferCurrentMod',     bg_current, fg_modified)
+    hl.set_default('BufferCurrentSign',    bg_current, fg_special)
+    hl.set_default('BufferCurrentTarget',  bg_current, fg_target, true)
+    hl.set_default('BufferInactive',       bg_inactive, fg_inactive)
+    hl.set_default('BufferInactiveIndex',  bg_inactive, fg_subtle)
+    hl.set_default('BufferInactiveMod',    bg_inactive, fg_modified)
+    hl.set_default('BufferInactiveSign',   bg_inactive, fg_subtle)
+    hl.set_default('BufferInactiveTarget', bg_inactive, fg_target, true)
+    hl.set_default('BufferTabpageFill',    bg_inactive, fg_inactive)
+    hl.set_default('BufferTabpages',       bg_inactive, fg_special, true)
+    hl.set_default('BufferVisible',        bg_visible, fg_visible)
+    hl.set_default('BufferVisibleIndex',   bg_visible, fg_visible)
+    hl.set_default('BufferVisibleMod',     bg_visible, fg_modified)
+    hl.set_default('BufferVisibleSign',    bg_visible, fg_visible)
+    hl.set_default('BufferVisibleTarget',  bg_visible, fg_target, true)
 
     hl.set_default_link('BufferCurrentIcon', 'BufferCurrent')
     hl.set_default_link('BufferInactiveIcon', 'BufferInactive')

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -23,8 +23,7 @@ local function set_highlights()
   for _, hl_group in ipairs(hl_groups) do
     local icon_hl = hl_group[1]
     local buffer_status = hl_group[2]
-    local set_default_hl = hl.get_default_setter()
-    set_default_hl(
+    hl.set_default(
       icon_hl .. buffer_status,
       hl.bg_or_default({'Buffer' .. buffer_status}, 'none'),
       hl.fg_or_default({icon_hl}, 'none')
@@ -71,10 +70,8 @@ local function get_icon(buffer_name, filetype, buffer_status)
   end
 
   if icon_hl and hlexists(icon_hl .. buffer_status) < 1 then
-    local hl_group = icon_hl .. buffer_status
-    local set_default_hl = hl.get_default_setter()
-    set_default_hl(
-      hl_group,
+    hl.set_default(
+      icon_hl .. buffer_status,
       hl.bg_or_default({'Buffer' .. buffer_status}, 'none'),
       hl.fg_or_default({icon_hl}, 'none')
     )


### PR DESCRIPTION
Sometimes barbar.nvim loads before the user's preferred `termguicolors` is set; this could especially happen if they lazy load their configuration until after barbar.nvim sets itself up with the `plugin/bufferlin.lua` file.

I was aware that this bug could occur, however I was ~~lazy~~ hoping that I could save performance by only setting highlights for the current `termguicolors`.

~~__Note:__ the diff will look better after merging #258~~

Closes #256