### PR TITLE
feat/116

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -280,8 +280,9 @@ end
 -- Section: Bufferline state
 ----------------------------
 
--- Last value for tabline
-local last_tabline = ''
+--- Last value for tabline
+--- @type nil|string
+local last_tabline
 
 -- Debugging
 -- let g:events = []
@@ -294,19 +295,17 @@ local last_tabline = ''
 --- @param update_names boolean if `true`, update the names of the buffers in the bufferline.
 --- @return nil|string tabline a valid `&tabline`
 function bufferline.render(update_names)
-  local result = require'bufferline.render'.render_safe(update_names)
+  local ok, result = unpack(require'bufferline.render'.render_safe(update_names))
 
-  if result[1] then
-    return result[2]
+  if ok then
+    return result
   end
-
-  local err = result[2]
 
   bufferline.disable()
   notify(
     "Barbar detected an error while running. Barbar disabled itself :/" ..
       "Include this in your report: " ..
-      tostring(err),
+      tostring(result),
     vim.log.levels.ERROR,
     {title = 'barbar.nvim'}
   )

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -84,7 +84,7 @@ function bufferline.enable()
 
   create_autocmd('BufModifiedSet', {
     callback = function()
-      local is_modified = buf_get_option(0, 'modified')
+      local is_modified = vim.bo.modified
       if is_modified ~= vim.b.checked then
         vim.b.checked = is_modified
         bufferline.update()

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -7,6 +7,7 @@ local defer_fn = vim.defer_fn
 local notify = vim.notify
 local tbl_extend = vim.tbl_extend
 
+local bbye = require'bufferline.bbye'
 local highlight = require 'bufferline.highlight'
 
 --- The default options for this plugin.
@@ -204,19 +205,19 @@ function bufferline.setup(options)
 
   create_user_command(
     'BufferClose',
-    function(tbl) require'bufferline.bbye'.delete('bdelete', tbl.bang, tbl.args, tbl.mods) end,
+    function(tbl) bbye.bdelete(tbl.bang, tbl.args, tbl.mods) end,
     {bang = true, complete = 'buffer', desc = 'Close the current buffer.', nargs = '?'}
   )
 
   create_user_command(
     'BufferDelete',
-    function(tbl) require'bufferline.bbye'.delete('bdelete', tbl.bang, tbl.args, tbl.mods) end,
+    function(tbl) bbye.bdelete(tbl.bang, tbl.args, tbl.mods) end,
     {bang = true, complete = 'buffer', desc = 'Synonym for `:BufferClose`', nargs = '?'}
   )
 
   create_user_command(
     'BufferWipeout',
-    function(tbl) require'bufferline.bbye'.delete('bwipeout', tbl.bang, tbl.args, tbl.mods) end,
+    function(tbl) bbye.bwipeout(tbl.bang, tbl.args, tbl.mods) end,
     {bang = true, complete = 'buffer', desc = 'Wipe out the buffer', nargs = '?'}
   )
 
@@ -348,7 +349,7 @@ function bufferline.main_click_handler(minwid, _, btn, _)
 
   -- NOTE: in Vimscript this was not `==`, it was a regex compare `=~`
   if btn == 'm' then
-    require'bufferline.bbye'.delete('bdelete', false, minwid)
+    bbye.bdelete(false, minwid)
   else
     require'bufferline.state'.open_buffer_in_listed_window(minwid)
   end

--- a/lua/bufferline/bbye.lua
+++ b/lua/bufferline/bbye.lua
@@ -175,4 +175,20 @@ function bbye.delete(action, force, buffer, mods)
   exec_autocmds('BufWinEnter', {})
 end
 
+--- 'bdelete' a buffer
+--- @param force boolean if true, forcefully delete the buffer
+--- @param buffer integer|nil|string the name of the buffer.
+--- @param mods nil|string the modifiers to the command (e.g. `'verbose'`)
+function bbye.bdelete(force, buffer, mods)
+  bbye.delete('bdelete', force, buffer, mods)
+end
+
+--- 'bwipeout' a buffer
+--- @param force boolean if true, forcefully delete the buffer
+--- @param buffer integer|nil|string the name of the buffer.
+--- @param mods nil|string the modifiers to the command (e.g. `'verbose'`)
+function bbye.bwipeout(force, buffer, mods)
+  bbye.delete('bwipeout', force, buffer, mods)
+end
+
 return bbye

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -17,6 +17,7 @@ local buf_get_option = vim.api.nvim_buf_get_option
 local buf_get_var = vim.api.nvim_buf_get_var
 local buf_is_valid = vim.api.nvim_buf_is_valid
 local buf_line_count = vim.api.nvim_buf_line_count
+local buf_set_var = vim.api.nvim_buf_set_var
 local bufadd = vim.fn.bufadd
 local bufwinnr = vim.fn.bufwinnr
 local command = vim.api.nvim_command
@@ -118,7 +119,7 @@ end
 
 function M.toggle_pin(bufnr)
   bufnr = bufnr or 0
-  vim.b[bufnr][PIN] = not M.is_pinned(bufnr)
+  buf_set_var(bufnr, PIN, not M.is_pinned(bufnr))
   sort_pins_to_left()
   M.update()
 end

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -605,7 +605,7 @@ function M.close_all_but_current()
   local buffers = M.buffers
   for _, number in ipairs(buffers) do
     if number ~= current then
-      bbye.delete('bdelete', false, number)
+      bbye.bdelete(false, number)
     end
   end
   M.update()
@@ -615,7 +615,7 @@ function M.close_all_but_pinned()
   local buffers = M.buffers
   for _, number in ipairs(buffers) do
     if not M.is_pinned(number) then
-      bbye.delete('bdelete', false, number)
+      bbye.bdelete(false, number)
     end
   end
   M.update()
@@ -626,7 +626,7 @@ function M.close_all_but_current_or_pinned()
   local current = get_current_buf()
   for _, number in ipairs(buffers) do
     if not M.is_pinned(number) and number ~= current then
-      bbye.delete('bdelete', false, number)
+      bbye.bdelete(false, number)
     end
   end
   M.update()
@@ -638,7 +638,7 @@ function M.close_buffers_left()
     return
   end
   for i = idx, 1, -1 do
-    bbye.delete('bdelete', false, M.buffers[i])
+    bbye.bdelete(false, M.buffers[i])
   end
   M.update()
 end
@@ -649,7 +649,7 @@ function M.close_buffers_right()
     return
   end
   for i = #M.buffers, idx, -1 do
-    bbye.delete('bdelete', false, M.buffers[i])
+    bbye.bdelete(false, M.buffers[i])
   end
   M.update()
 end


### PR DESCRIPTION
908587eddeff7c0a4962af08ad36e1dc96f05236 is a little bit of a hack. I couldn't find any API function to save a specific buffer, or run a function from within a buffer context, or anything like that. So I had to save the current buffer, switch to the buffer that needs saving, and then switch back after saving.

There are some adjacently-related changes in this PR, namely deduping the `action` argument to `bbye.delete` and cleaning up the global namespace when barbar is disabled.

Closes #116.