### PR TITLE
fix(bufferline): `redraw`ing whole screen when only `&tabline` changed

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -151,7 +151,7 @@ function bufferline.enable()
   ]]
 
   bufferline.update()
-  command('redraw')
+  command('redrawtabline')
 end
 
 --- Setup this plugin.

--- a/lua/bufferline/jump_mode.lua
+++ b/lua/bufferline/jump_mode.lua
@@ -133,7 +133,7 @@ function JumpMode.activate()
 
   state.is_picking_buffer = true
   state.update()
-  command('redraw')
+  command('redrawtabline')
   state.is_picking_buffer = false
 
   local ok, byte = pcall(getchar)
@@ -153,7 +153,7 @@ function JumpMode.activate()
   end
 
   state.update()
-  command('redraw')
+  command('redrawtabline')
 end
 
 JumpMode.set_letters(vim.g.bufferline.letters)


### PR DESCRIPTION
This is also a performance improvement.

Closes #266.