### PR TITLE
feat: `BufferScrollLeft`/`Right`

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -166,13 +166,13 @@ function bufferline.setup(options)
 
   create_user_command(
     'BufferNext',
-    function(tbl) require'bufferline.state'.goto_buffer_relative(math.max(tbl.count, 1)) end,
+    function(tbl) require'bufferline.state'.goto_buffer_relative(math.max(1, tbl.count)) end,
     {count = true, desc = 'Go to the next buffer'}
   )
 
   create_user_command(
     'BufferPrevious',
-    function(tbl) require'bufferline.state'.goto_buffer_relative(-math.max(tbl.count, 1)) end,
+    function(tbl) require'bufferline.state'.goto_buffer_relative(-math.max(1, tbl.count)) end,
     {count = true, desc = 'Go to the previous buffer'}
   )
 
@@ -193,13 +193,13 @@ function bufferline.setup(options)
 
   create_user_command(
     'BufferMoveNext',
-    function(tbl) require'bufferline.state'.move_current_buffer(math.max(tbl.count, 1)) end,
+    function(tbl) require'bufferline.state'.move_current_buffer(math.max(1, tbl.count)) end,
     {count = true, desc = 'Move the current buffer to the right'}
   )
 
   create_user_command(
     'BufferMovePrevious',
-    function(tbl) require'bufferline.state'.move_current_buffer(-math.max(tbl.count, 1)) end,
+    function(tbl) require'bufferline.state'.move_current_buffer(-math.max(1, tbl.count)) end,
     {count = true, desc = 'Move the current buffer to the left'}
   )
 
@@ -277,6 +277,24 @@ function bufferline.setup(options)
     'BufferCloseBuffersRight',
     function() require'bufferline.state'.close_buffers_right() end,
     {desc = 'Close all buffers to the right of the current buffer'}
+  )
+
+  create_user_command(
+    'BufferScrollLeft',
+    function(tbl)
+      local state = require'bufferline.state'
+      state.set_scroll(math.max(0, state.scroll - math.max(1, tbl.count)))
+    end,
+    {count = true, desc = 'Scroll the bufferline left'}
+  )
+
+  create_user_command(
+    'BufferScrollRight',
+    function(tbl)
+      local state = require'bufferline.state'
+      state.set_scroll(state.scroll + math.max(1, tbl.count))
+    end,
+    {count = true, desc = 'Scroll the bufferline right'}
   )
 
   -- Set the options and watchers for when they are edited

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -11,7 +11,7 @@ local notify = vim.notify
 local tbl_extend = vim.tbl_extend
 
 local bbye = require'bufferline.bbye'
-local highlight = require 'bufferline.highlight'
+local highlight = require'bufferline.highlight'
 
 --- The default options for this plugin.
 local DEFAULT_OPTIONS = {
@@ -327,10 +327,11 @@ end
 --------------------------
 
 --- Render the bufferline.
---- @param update_names boolean if `true`, update the names of the buffers in the bufferline.
+--- @param refocus nil|boolean if `true`, the bufferline will be refocused on the current buffer (default: `true`)
+--- @param update_names nil|boolean whether to refresh the names of the buffers (default: `false`)
 --- @return nil|string tabline a valid `&tabline`
-function bufferline.render(update_names)
-  local ok, result = unpack(require'bufferline.render'.render_safe(update_names))
+function bufferline.render(update_names, refocus)
+  local ok, result = xpcall(require'bufferline.render'.render, debug.traceback, update_names, refocus)
 
   if ok then
     return result
@@ -346,14 +347,14 @@ function bufferline.render(update_names)
   )
 end
 
---- @param update_names boolean|nil if `true`, update the names of the buffers in the bufferline. Default: false
-function bufferline.update(update_names)
+--- @param refocus nil|boolean if `true`, the bufferline will be refocused on the current buffer (default: `true`)
+--- @param update_names nil|boolean whether to refresh the names of the buffers (default: `false`)
+function bufferline.update(update_names, refocus)
   if vim.g.SessionLoad then
     return
   end
 
-  local new_value = bufferline.render(update_names or false)
-
+  local new_value = bufferline.render(update_names, refocus)
   if new_value == last_tabline then
     return
   end

--- a/lua/bufferline/jump_mode.lua
+++ b/lua/bufferline/jump_mode.lua
@@ -15,6 +15,7 @@ local split = vim.fn.split
 local strcharpart = vim.fn.strcharpart
 local strwidth = vim.api.nvim_strwidth
 
+local bufferline = require'bufferline'
 local state = require'bufferline.state'
 
 ----------------------------------------
@@ -132,7 +133,7 @@ function JumpMode.activate()
   end
 
   state.is_picking_buffer = true
-  state.update()
+  bufferline.update()
   command('redrawtabline')
   state.is_picking_buffer = false
 
@@ -152,7 +153,7 @@ function JumpMode.activate()
     notify("Invalid input", vim.log.levels.WARN, {title = 'barbar.nvim'})
   end
 
-  state.update()
+  bufferline.update()
   command('redrawtabline')
 end
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -173,7 +173,11 @@ end
 
 -- Rendering
 
-local function render(update_names)
+--- Generate a valid `&tabline` given the current state of Neovim.
+--- @param refocus nil|boolean if `true`, the bufferline will be refocused on the current buffer (default: `true`)
+--- @param update_names nil|boolean whether to refresh the names of the buffers (default: `false`)
+--- @return nil|string syntax
+local function render(update_names, refocus)
   local opts = vim.g.bufferline
   local buffer_numbers = state.get_updated_buffers(update_names)
 
@@ -328,7 +332,7 @@ local function render(update_names)
       }
     }
 
-    if is_current then
+    if is_current and refocus ~= false then
       current_buffer_index = i
       current_buffer_position = buffer_data.real_position
 
@@ -411,14 +415,6 @@ local function render(update_names)
   return result
 end
 
-local function render_safe(update_names)
-  local ok, result = xpcall(render, debug.traceback, update_names)
-  return {ok, tostring(result)}
-end
-
 -- print(render(state.buffers))
 
-return {
-  render = render,
-  render_safe = render_safe,
-}
+return { render = render }

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -92,10 +92,6 @@ function M.get_buffer_data(id)
   return M.buffers_by_id[id]
 end
 
-function M.update()
-  bufferline.update()
-end
-
 
 -- Pinned buffers
 
@@ -121,7 +117,7 @@ function M.toggle_pin(bufnr)
   bufnr = bufnr or 0
   buf_set_var(bufnr, PIN, not M.is_pinned(bufnr))
   sort_pins_to_left()
-  M.update()
+  bufferline.update()
 end
 
 -- Scrolling
@@ -133,7 +129,7 @@ local function set_scroll_tick(new_scroll, animation)
   if animation.running == false then
     scroll_animation = nil
   end
-  M.update()
+  bufferline.update(nil, false)
 end
 
 function M.set_scroll(target)
@@ -158,7 +154,7 @@ local function open_buffer_animated_tick(buffer_number, new_width, animation)
   else
     buffer_data.width = nil
   end
-  M.update()
+  bufferline.update()
 end
 
 local function open_buffer_start_animation(layout, buffer_number)
@@ -283,14 +279,14 @@ function M.close_buffer(buffer_number, should_update_names)
   if should_update_names then
     M.update_names()
   end
-  M.update()
+  bufferline.update()
 end
 
 local function close_buffer_animated_tick(buffer_number, new_width, animation)
   if new_width > 0 and M.buffers_by_id[buffer_number] ~= nil then
     local buffer_data = M.get_buffer_data(buffer_number)
     buffer_data.width = new_width
-    M.update()
+    bufferline.update()
     return
   end
   animate.stop(animation)
@@ -434,7 +430,7 @@ function M.set_offset(offset, offset_text, offset_hl)
       M.offset = offset_number
       M.offset_text = offset_text or ''
       M.offset_hl = offset_hl
-      M.update()
+      bufferline.update()
   end
 end
 
@@ -462,7 +458,7 @@ local function move_buffer_animated_tick(ratio, current_animation)
     end
   end
 
-  M.update()
+  bufferline.update()
 
   if current_animation.running == false then
     move_animation = nil
@@ -518,7 +514,7 @@ local function move_buffer_animated(from_idx, to_idx)
     animate.start(ANIMATION_MOVE_DURATION, 0, 1, vim.v.t_float,
       function(ratio, current_animation) move_buffer_animated_tick(ratio, current_animation) end)
 
-  M.update()
+  bufferline.update()
 end
 
 local function move_buffer_direct(from_idx, to_idx)
@@ -527,7 +523,7 @@ local function move_buffer_direct(from_idx, to_idx)
   table_insert(M.buffers, to_idx, buffer_number)
   sort_pins_to_left()
 
-  M.update()
+  bufferline.update()
 end
 
 local function move_buffer(from_idx, to_idx)
@@ -609,7 +605,7 @@ function M.close_all_but_current()
       bbye.bdelete(false, number)
     end
   end
-  M.update()
+  bufferline.update()
 end
 
 function M.close_all_but_pinned()
@@ -619,7 +615,7 @@ function M.close_all_but_pinned()
       bbye.bdelete(false, number)
     end
   end
-  M.update()
+  bufferline.update()
 end
 
 function M.close_all_but_current_or_pinned()
@@ -630,7 +626,7 @@ function M.close_all_but_current_or_pinned()
       bbye.bdelete(false, number)
     end
   end
-  M.update()
+  bufferline.update()
 end
 
 function M.close_buffers_left()
@@ -641,7 +637,7 @@ function M.close_buffers_left()
   for i = idx, 1, -1 do
     bbye.bdelete(false, M.buffers[i])
   end
-  M.update()
+  bufferline.update()
 end
 
 function M.close_buffers_right()
@@ -652,7 +648,7 @@ function M.close_buffers_right()
   for i = #M.buffers, idx, -1 do
     bbye.bdelete(false, M.buffers[i])
   end
-  M.update()
+  bufferline.update()
 end
 
 
@@ -680,7 +676,7 @@ function M.order_by_buffer_number()
   table_sort(M.buffers, function(a, b)
     return a < b
   end)
-  M.update()
+  bufferline.update()
 end
 
 function M.order_by_directory()
@@ -711,7 +707,7 @@ function M.order_by_directory()
       return a_less_than_b
     end)
   )
-  M.update()
+  bufferline.update()
 end
 
 function M.order_by_language()
@@ -721,7 +717,7 @@ function M.order_by_language()
       return fnamemodify(buf_get_name(a), ':e') < fnamemodify(buf_get_name(b), ':e')
     end)
   )
-  M.update()
+  bufferline.update()
 end
 
 function M.order_by_window_number()
@@ -731,7 +727,7 @@ function M.order_by_window_number()
       return bufwinnr(buf_get_name(a)) < bufwinnr(buf_get_name(b))
     end)
   )
-  M.update()
+  bufferline.update()
 end
 
 -- vim-session integration
@@ -788,7 +784,7 @@ function M.restore_buffers(bufnames)
     local bufnr = bufadd(name)
     table_insert(M.buffers, bufnr)
   end
-  M.update()
+  bufferline.update()
 end
 
 -- Exports


### PR DESCRIPTION
This PR adds scrolling the bufferline via `<COUNT>BufferScrollLeft`/`Right`.

To accomplish this, a new parameter to several functions had to be added: `refocus`. On master, barbar.nvim will default to always keeping the current buffer in view— but to scroll very far you have to be able to stop this from happening temporarily.

A side effect of this was flattening a few aliases in order to reduce the odds of any changes to `render` not having their options supported by one or two specific functions (which would be challenging to figure out if missed)

Closes #54