### PR TITLE
nvim-tree integration fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ local nvim_tree_events = require('nvim-tree.events')
 local bufferline_state = require('bufferline.state')
 
 local function get_tree_size()
-  return vim.api.nvim_win_get_width(0)
+  return require"nvim-tree.view".View.width
 end
 
 nvim_tree_events.subscribe('TreeOpen', function()

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ local nvim_tree_events = require('nvim-tree.events')
 local bufferline_state = require('bufferline.state')
 
 local function get_tree_size()
-  return require"nvim-tree.view".View.width
+  return require'nvim-tree.view'.View.width
 end
 
 nvim_tree_events.subscribe('TreeOpen', function()


### PR DESCRIPTION
Alright, so the problem with the current solution is that `nvim_win_get_width(0)` returns the width for the *current* window. Why? Because when we open file in the tree, it focuses the editor window, which is not what we want.

Instead, according to the [readme](https://github.com/kyazdani42/nvim-tree.lua#tips--tricks) of the nvim-tree plugin, `require"nvim-tree.view".View` returns a very useful set of info, among which, its width.

Tested:
1. Opened vim with one buffer
2. Toggle the tree (resized correctly)
3. Open file from the tree
4. Open folder from the tree
