### PR TITLE
Add BufferMoveStart command

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -79,6 +79,12 @@ function bufferline.setup(user_config)
     {count = true, desc = 'Move the current buffer to the left'}
   )
 
+  create_user_command(
+    'BufferMoveStart',
+    function(tbl) api.move_current_buffer_to(1) end,
+    {desc = 'Move current buffer to the front'}
+  )
+
   create_user_command('BufferPick', api.pick_buffer, {desc = 'Pick a buffer'})
 
   create_user_command('BufferPin', function() api.toggle_pin() end, {desc = 'Un/pin a buffer'})


### PR DESCRIPTION
The `state.move_current_buffer_to` function has a bug when the current buffer is not the the tabline, instead of doing nothing because the current buffer is not in the list, it removes the first buffer from the list, pushing it back to the last position when the buffer is re-added later on.

Also, create a command BufferMoveStart that uses this function. See use case in #284 (and investigation of the above issue)