### PR TITLE
docs(render): minor LSP annotation fix

### DIFF
--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -127,7 +127,7 @@ end
 --- @param groups bufferline.render.group[]
 --- @param position integer
 --- @param others bufferline.render.group[]
---- @return bufferline.render.group with_insertions[]
+--- @return bufferline.render.group[] with_insertions
 local function groups_insert(groups, position, others)
   local current_position = 0
 


### PR DESCRIPTION
`@return` uses `<type> <name>`, whereas `@param` uses `<name> <type>`. I accidentally confused the two here.