### PR TITLE
fix: lazy loading

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -1,7 +1,6 @@
 local command = vim.api.nvim_command
 local create_user_command = vim.api.nvim_create_user_command
 local get_current_buf = vim.api.nvim_get_current_buf
-local tbl_extend = vim.tbl_extend
 local validate = vim.validate
 
 --- @type bufferline.api
@@ -16,39 +15,14 @@ local highlight = require'bufferline.highlight'
 --- @type bufferline.JumpMode
 local JumpMode = require'bufferline.jump_mode'
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 --- @type bufferline.render
 local render = require'bufferline.render'
 
 --- @type bufferline.state
 local state = require'bufferline.state'
-
---- @class bufferline.Options the available options for this plugin, and their defaults.
---- @field exclude_ft string[]
---- @field exclude_name string[]
-local DEFAULT_OPTIONS = {
-  animation = true,
-  auto_hide = false,
-  clickable = true,
-  closable = true,
-  exclude_ft = {},
-  exclude_name = {},
-  icon_close_tab = '',
-  icon_close_tab_modified = '●',
-  icon_pinned = '',
-  icon_separator_active =   '▎',
-  icon_separator_inactive = '▎',
-  icons = true,
-  icon_custom_colors = false,
-  insert_at_start = false,
-  insert_at_end = false,
-  letters = 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP',
-  maximum_padding = 4,
-  minimum_padding = 1,
-  maximum_length = 30,
-  no_name_title = nil,
-  semantic_letters = true,
-  tabpages = true,
-}
 
 -------------------------------
 -- Section: `bufferline` module
@@ -58,8 +32,8 @@ local DEFAULT_OPTIONS = {
 local bufferline = {}
 
 --- Setup this plugin.
---- @param options? bufferline.Options
-function bufferline.setup(options)
+--- @param user_config? table
+function bufferline.setup(user_config)
   -- Show the tabline
   vim.opt.showtabline = 2
 
@@ -198,10 +172,10 @@ function bufferline.setup(options)
   )
 
   -- Set the options and watchers for when they are edited
-  vim.g.bufferline = options and tbl_extend('keep', options, DEFAULT_OPTIONS) or DEFAULT_OPTIONS
+  vim.g.bufferline = user_config
 
   highlight.setup()
-  JumpMode.set_letters(vim.g.bufferline.letters)
+  JumpMode.set_letters(options.letters())
   render.enable()
 end
 

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -211,10 +211,11 @@ local function move_buffer(from_idx, to_idx)
     return
   end
 
+  local animation = options.animation()
   local bufnr = state.buffers[from_idx]
 
   local previous_positions
-  if options.animation() == true then
+  if animation == true then
     previous_positions = Layout.calculate_buffers_position_by_buffer_number()
   end
 
@@ -222,7 +223,7 @@ local function move_buffer(from_idx, to_idx)
   table_insert(state.buffers, to_idx, bufnr)
   state.sort_pins_to_left()
 
-  if options.animation() == true then
+  if animation == true then
     local current_index = utils.index_of(state.buffers, bufnr)
     local start_index = min(from_idx, current_index)
     local end_index   = max(from_idx, current_index)

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -29,6 +29,9 @@ local JumpMode = require'bufferline.jump_mode'
 --- @type bufferline.Layout
 local Layout = require'bufferline.layout'
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 --- @type bufferline.render
 local render = require'bufferline.render'
 
@@ -211,7 +214,7 @@ local function move_buffer(from_idx, to_idx)
   local bufnr = state.buffers[from_idx]
 
   local previous_positions
-  if vim.g.bufferline.animation == true then
+  if options.animation() == true then
     previous_positions = Layout.calculate_buffers_position_by_buffer_number()
   end
 
@@ -219,7 +222,7 @@ local function move_buffer(from_idx, to_idx)
   table_insert(state.buffers, to_idx, bufnr)
   state.sort_pins_to_left()
 
-  if vim.g.bufferline.animation == true then
+  if options.animation() == true then
     local current_index = utils.index_of(state.buffers, bufnr)
     local start_index = min(from_idx, current_index)
     local end_index   = max(from_idx, current_index)

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -14,6 +14,9 @@ local get_current_buf = vim.api.nvim_get_current_buf
 local matchlist = vim.fn.matchlist
 local split = vim.split
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 --- @type bufferline.utils
 local utils = require'bufferline.utils'
 
@@ -52,8 +55,8 @@ return {
     --- @type nil|string
     local name = buf_is_valid(bufnr) and buf_get_name(bufnr) or nil
 
-    local no_name_title = vim.g.bufferline.no_name_title
-    local maximum_length = vim.g.bufferline.maximum_length
+    local no_name_title = options.no_name_title()
+    local maximum_length = options.maximum_length()
 
     if name then
       name = buf_get_option(bufnr, 'buftype') == 'terminal' and terminalname(name) or utils.basename(name)

--- a/lua/bufferline/jump_mode.lua
+++ b/lua/bufferline/jump_mode.lua
@@ -8,6 +8,9 @@ local split = vim.fn.split
 local strcharpart = vim.fn.strcharpart
 local strwidth = vim.api.nvim_strwidth
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 ----------------------------------------
 -- Section: Buffer-picking mode state --
 ----------------------------------------
@@ -56,7 +59,7 @@ function JumpMode.assign_next_letter(bufnr)
   end
 
   -- First, try to assign a letter based on name
-  if vim.g.bufferline.semantic_letters == true then
+  if options.semantic_letters() == true then
     local name = fnamemodify(buf_get_name(bufnr), ':t:r')
 
     for i = 1, strwidth(name) do

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -14,6 +14,9 @@ local tabpagenr = vim.fn.tabpagenr
 --- @type bufferline.buffer
 local Buffer = require'bufferline.buffer'
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 --- @type bufferline.state
 local state = require'bufferline.state'
 
@@ -38,7 +41,7 @@ local Layout = {}
 function Layout.calculate_tabpages_width()
   local current = tabpagenr()
   local total   = tabpagenr('$')
-  if not vim.g.bufferline.tabpages or total == 1 then
+  if not options.tabpages() or total == 1 then
     return 0
   end
   return 1 + tostring(current):len() + 1 + tostring(total):len() + 1
@@ -46,8 +49,7 @@ end
 
 --- @param base_width integer
 function Layout.calculate_buffers_width(base_width)
-  local opts = vim.g.bufferline
-  local has_numbers = opts.icons == 'both' or opts.icons == 'numbers'
+  local has_numbers = options.icons() == 'both' or options.icons() == 'numbers'
 
   local sum = 0
   local widths = {}
@@ -62,8 +64,8 @@ function Layout.calculate_buffers_width(base_width)
     else
       width = base_width
         + strwidth(Buffer.get_activity(buffer_number) > 1 -- separator
-            and opts.icon_separator_active
-            or opts.icon_separator_inactive)
+            and options.icon_separator_active()
+            or options.icon_separator_inactive())
         + strwidth(buffer_name) -- name
 
       if has_numbers then
@@ -74,12 +76,12 @@ function Layout.calculate_buffers_width(base_width)
 
       local is_pinned = state.is_pinned(buffer_number)
 
-      if opts.closable or is_pinned then
+      if options.closable() or is_pinned then
         local is_modified = buf_get_option(buffer_number, 'modified')
-        local icon = is_pinned and opts.icon_pinned or
+        local icon = is_pinned and options.icon_pinned() or
           (not is_modified -- close-icon
-            and opts.icon_close_tab
-             or opts.icon_close_tab_modified)
+            and options.icon_close_tab()
+             or options.icon_close_tab_modified())
 
         width = width
           + strwidth(icon)
@@ -96,9 +98,7 @@ end
 --- Calculate the current layout of the bufferline.
 --- @return bufferline.layout.data
 function Layout.calculate()
-  local opts = vim.g.bufferline
-
-  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_number_with_icon')
+  local has_icons = (options.icons() == true) or (options.icons() == 'both') or (options.icons() == 'buffer_number_with_icon')
 
   -- [icon + space-after-icon] + space-after-name
   local base_width =
@@ -117,7 +117,7 @@ function Layout.calculate()
   local remaining_width              = max(buffers_width - used_width, 0)
   local remaining_width_per_buffer   = floor(remaining_width / buffers_length)
   local remaining_padding_per_buffer = floor(remaining_width_per_buffer / SIDES_OF_BUFFER)
-  local padding_width                = max(opts.minimum_padding, min(remaining_padding_per_buffer, opts.maximum_padding))
+  local padding_width                = max(options.minimum_padding(), min(remaining_padding_per_buffer, options.maximum_padding()))
   local actual_width                 = used_width + (buffers_length * padding_width * SIDES_OF_BUFFER)
 
   return {

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -49,7 +49,8 @@ end
 
 --- @param base_width integer
 function Layout.calculate_buffers_width(base_width)
-  local has_numbers = options.icons() == 'both' or options.icons() == 'numbers'
+  local icons = options.icons()
+  local has_numbers = icons == 'both' or icons == 'numbers'
 
   local sum = 0
   local widths = {}
@@ -98,7 +99,8 @@ end
 --- Calculate the current layout of the bufferline.
 --- @return bufferline.layout.data
 function Layout.calculate()
-  local has_icons = (options.icons() == true) or (options.icons() == 'both') or (options.icons() == 'buffer_number_with_icon')
+  local icons = options.icons()
+  local has_icons = (icons == true) or (icons == 'both') or (icons == 'buffer_number_with_icon')
 
   -- [icon + space-after-icon] + space-after-name
   local base_width =

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -1,0 +1,124 @@
+--- Retrieve some value under `key` from `g:bufferline`, or return a `default` if none was present.
+--- PERF: this implementation was profiled be an improvement over `vim.g.bufferline and vim.g.bufferline[key] or default`
+--- @generic T
+--- @param default? T
+--- @param key string
+--- @return T value
+local function get(key, default)
+  return (vim.g.bufferline or {})[key] or default
+end
+
+--- @class bufferline.options
+local options = {}
+
+--- @return boolean enabled
+function options.animation()
+  return get('animation', true)
+end
+
+--- @return boolean enabled
+function options.auto_hide()
+  return get('auto_hide', false)
+end
+
+--- @return boolean enabled
+function options.clickable()
+  return get('clickable', true)
+end
+
+--- @return boolean enabled
+function options.closable()
+  return get('closable', true)
+end
+
+--- @return string[] excluded
+function options.exclude_ft()
+  return get('exclude_ft', {})
+end
+
+--- @return string[] excluded
+function options.exclude_name()
+  return get('exclude_name', {})
+end
+
+--- @return string icon
+function options.icon_close_tab()
+  return get('icon_close_tab', '')
+end
+
+--- @return string icon
+function options.icon_close_tab_modified()
+  return get('icon_close_tab_modified', '●')
+end
+
+--- @return string icon
+function options.icon_pinned()
+  return get('icon_pinned', '')
+end
+
+--- @return string icon
+function options.icon_separator_active()
+  return get('icon_separator_active', '▎')
+end
+
+--- @return string icon
+function options.icon_separator_inactive()
+  return get('icon_separator_inactive', '▎')
+end
+
+--- @return boolean enabled
+function options.icons()
+  return get('icons', true)
+end
+
+--- @return boolean enabled
+function options.icon_custom_colors()
+  return get('icon_custom_colors', false)
+end
+
+--- @return boolean enabled
+function options.insert_at_start()
+  return get('insert_at_start', false)
+end
+
+--- @return boolean enabled
+function options.insert_at_end()
+  return get('insert_at_end', false)
+end
+
+--- @return string letters
+function options.letters()
+  return get('letters', 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP')
+end
+
+--- @return integer padding
+function options.maximum_padding()
+  return get('maximum_padding', 4)
+end
+
+--- @return integer padding
+function options.minimum_padding()
+  return get('minimum_padding', 1)
+end
+
+--- @return integer length
+function options.maximum_length()
+  return get('maximum_length', 30)
+end
+
+--- @return nil|string title
+function options.no_name_title()
+  return get('no_name_title')
+end
+
+--- @return boolean enabled
+function options.semantic_letters()
+  return get('semantic_letters', true)
+end
+
+--- @return boolean enabled
+function options.tabpages()
+  return get('tabpages', true)
+end
+
+return options

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -61,6 +61,9 @@ local JumpMode = require'bufferline.jump_mode'
 --- @type bufferline.Layout
 local Layout = require'bufferline.layout'
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 --- @type bufferline.state
 local state = require'bufferline.state'
 
@@ -277,7 +280,7 @@ end
 --- Same as `close_buffer`, but animated.
 --- @param bufnr integer
 function render.close_buffer_animated(bufnr)
-  if vim.g.bufferline.animation == false then
+  if options.animation() == false then
     return state.close_buffer(bufnr)
   end
 
@@ -348,7 +351,6 @@ end
 
 --- Open the `new_buffers` in the bufferline.
 local function open_buffers(new_buffers)
-  local opts = vim.g.bufferline
   local initial_buffers = #state.buffers
 
   -- Open next to the currently opened tab
@@ -365,8 +367,8 @@ local function open_buffers(new_buffers)
     if utils.index_of(state.buffers, new_buffer) == nil then
       local actual_index = new_index
 
-      local should_insert_at_start = opts.insert_at_start
-      local should_insert_at_end = opts.insert_at_end or
+      local should_insert_at_start = options.insert_at_start()
+      local should_insert_at_end = options.insert_at_end() or
         -- We add special buffers at the end
         buf_get_option(new_buffer, 'buftype') ~= ''
 
@@ -386,7 +388,7 @@ local function open_buffers(new_buffers)
   state.sort_pins_to_left()
 
   -- We're done if there is no animations
-  if opts.animation == false then
+  if options.animation() == false then
     return
   end
 
@@ -596,7 +598,7 @@ end
 --- @param key string what option was changed.
 function render.on_option_changed(_, key, _)
   if vim.g.bufferline and key == 'letters' then
-    JumpMode.set_letters(vim.g.bufferline.letters)
+    JumpMode.set_letters(options.letters())
   end
 end
 
@@ -687,9 +689,7 @@ end
 --- @param refocus? boolean if `true`, the bufferline will be refocused on the current buffer (default: `true`)
 --- @return nil|string syntax
 local function generate_tabline(bufnrs, refocus)
-  local opts = vim.g.bufferline
-
-  if opts.auto_hide then
+  if options.auto_hide() then
     if #bufnrs <= 1 then
       if vim.o.showtabline == 2 then
         vim.o.showtabline = 0
@@ -712,12 +712,12 @@ local function generate_tabline(bufnrs, refocus)
     end
   end
 
-  local click_enabled = has('tablineat') and opts.clickable
-  local has_close = opts.closable
-  local has_icons = (opts.icons == true) or (opts.icons == 'both') or (opts.icons == 'buffer_number_with_icon')
-  local has_icon_custom_colors = opts.icon_custom_colors
-  local has_buffer_number = (opts.icons == 'buffer_numbers') or (opts.icons == 'buffer_number_with_icon')
-  local has_numbers = (opts.icons == 'numbers') or (opts.icons == 'both')
+  local click_enabled = has('tablineat') and options.clickable()
+  local has_close = options.closable()
+  local has_icons = (options.icons() == true) or (options.icons() == 'both') or (options.icons() == 'buffer_number_with_icon')
+  local has_icon_custom_colors = options.icon_custom_colors()
+  local has_buffer_number = (options.icons() == 'buffer_numbers') or (options.icons() == 'buffer_number_with_icon')
+  local has_numbers = (options.icons() == 'numbers') or (options.icons() == 'both')
 
   local layout = Layout.calculate()
 
@@ -746,8 +746,8 @@ local function generate_tabline(bufnrs, refocus)
 
     local separatorPrefix = hl_tabline('Buffer' .. status .. 'Sign')
     local separator = is_inactive and
-      opts.icon_separator_inactive or
-      opts.icon_separator_active
+      options.icon_separator_inactive() or
+      options.icon_separator_active()
 
     local namePrefix = hl_tabline('Buffer' .. status .. mod)
     local name = buffer_name
@@ -797,10 +797,10 @@ local function generate_tabline(bufnrs, refocus)
     if has_close or is_pinned then
       local closeIcon =
         is_pinned and
-          opts.icon_pinned or
+          options.icon_pinned() or
         (not is_modified and
-          opts.icon_close_tab or
-          opts.icon_close_tab_modified)
+          options.icon_close_tab() or
+          options.icon_close_tab_modified())
 
       closePrefix = namePrefix
       close = closeIcon .. ' '
@@ -905,8 +905,8 @@ local function generate_tabline(bufnrs, refocus)
   -- To prevent the expansion of the last click group
   result = result .. '%0@BufferlineMainClickHandler@' .. hl_tabline('BufferTabpageFill')
 
-  if layout.actual_width + strwidth(opts.icon_separator_inactive) <= layout.buffers_width and #items > 0 then
-    result = result .. opts.icon_separator_inactive
+  if layout.actual_width + strwidth(options.icon_separator_inactive()) <= layout.buffers_width and #items > 0 then
+    result = result .. options.icon_separator_inactive()
   end
 
   local current_tabpage = tabpagenr()

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -712,12 +712,14 @@ local function generate_tabline(bufnrs, refocus)
     end
   end
 
+  local icons_enabled = options.icons()
+
   local click_enabled = has('tablineat') and options.clickable()
   local has_close = options.closable()
-  local has_icons = (options.icons() == true) or (options.icons() == 'both') or (options.icons() == 'buffer_number_with_icon')
+  local has_icons = (icons_enabled == true) or (icons_enabled == 'both') or (icons_enabled == 'buffer_number_with_icon')
   local has_icon_custom_colors = options.icon_custom_colors()
-  local has_buffer_number = (options.icons() == 'buffer_numbers') or (options.icons() == 'buffer_number_with_icon')
-  local has_numbers = (options.icons() == 'numbers') or (options.icons() == 'both')
+  local has_buffer_number = (icons_enabled == 'buffer_numbers') or (icons_enabled == 'buffer_number_with_icon')
+  local has_numbers = (icons_enabled == 'numbers') or (icons_enabled == 'both')
 
   local layout = Layout.calculate()
 

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -16,6 +16,9 @@ local tbl_filter = vim.tbl_filter
 --- @type bufferline.buffer
 local Buffer = require'bufferline.buffer'
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 --- @type bufferline.utils
 local utils = require'bufferline.utils'
 
@@ -75,8 +78,8 @@ function state.get_buffer_list()
   local buffers = list_bufs()
   local result = {}
 
-  local exclude_ft   = vim.g.bufferline.exclude_ft
- local exclude_name = vim.g.bufferline.exclude_name
+  local exclude_ft   = options.exclude_ft()
+  local exclude_name = options.exclude_name()
 
   for _, buffer in ipairs(buffers) do
     if not buf_get_option(buffer, 'buflisted') then


### PR DESCRIPTION
This plugin has had some pretty persistent problems with lazy loading (#293, #292, #281, #218, etc).

Most of these stem from the fact that many users opt to overwriting `vim.g.bufferline` themselves, and sometimes (due to variances in configuration) this occurs _after_ our `plugin/bufferline.lua` file has called the initial `bufferline.setup()` function. This means that we end up with a `vim.g.bufferline` which has no default values, and thus when we rightly assume that they will be present, errors start getting thrown at the user.

To solve this, I created an `options` module which resolves the correct value for each setting when it is accessed, rather than at `setup`. This _does_ incur a bit of overhead, but I think it will be worth it in the end if we can finally be rid of these issues!

Closes #293