### PR TITLE
feat: hide buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ let bufferline.clickable = v:true
 let bufferline.exclude_ft = ['javascript']
 let bufferline.exclude_name = ['package.json']
 
+" Show every buffer
+let bufferline.hide = {'current': v:false, 'inactive': v:false, 'visible': v:false}
+
 " Enable/disable icons
 " if set to 'buffer_number', will show buffer number in the tabline
 " if set to 'numbers', will show buffer index in the tabline
@@ -305,6 +308,10 @@ require'bufferline'.setup {
   -- Excludes buffers from the tabline
   exclude_ft = {'javascript'},
   exclude_name = {'package.json'},
+
+  -- Show every buffer
+  hide = {current = false, inactive = false, visible = false},
+
 
   -- Enable/disable icons
   -- if set to 'numbers', will show buffer index in the tabline

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -308,6 +308,15 @@ Controls if icons are rendered on each tab.
 >
     let g:bufferline.no_name_title = v:null
 <
+
+                                                           *g:bufferline.hide*
+`g:bufferline.hide`  table  (default |v:false| for all)
+
+  Sets which buffers are hidden in the bufferline: `current`, `inactive`, and
+  `visible` are possible.
+>
+    let g:bufferline.hide = {'current': v:false, 'inactive': v:true}
+<
 ==============================================================================
 5. Integrations                                          *barbar-integrations*
 

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -190,7 +190,7 @@ local move_animation_data = nil
 local function move_buffer_animated_tick(ratio, current_animation)
   local data = move_animation_data
 
-  for _, current_number in ipairs(state.buffers) do
+  for _, current_number in ipairs(Layout.buffers) do
     local current_data = state.get_buffer_data(current_number)
 
     if current_animation.running == true then
@@ -236,7 +236,7 @@ local function move_buffer(from_idx, to_idx)
   state.sort_pins_to_left()
 
   if animation == true then
-    local current_index = utils.index_of(state.buffers, bufnr)
+    local current_index = utils.index_of(Layout.buffers, bufnr)
     local start_index = min(from_idx, current_index)
     local end_index   = max(from_idx, current_index)
 
@@ -248,15 +248,14 @@ local function move_buffer(from_idx, to_idx)
 
     local next_positions = Layout.calculate_buffers_position_by_buffer_number()
 
-    for i, _ in ipairs(state.buffers) do
-      local current_number = state.buffers[i]
-      local current_data = state.get_buffer_data(current_number)
+    for _, layout_bufnr  in ipairs(Layout.buffers) do
+      local current_data = state.get_buffer_data(layout_bufnr)
 
-      local previous_position = previous_positions[current_number]
-      local next_position     = next_positions[current_number]
+      local previous_position = previous_positions[layout_bufnr]
+      local next_position     = next_positions[layout_bufnr]
 
       if next_position ~= previous_position then
-        current_data.position = previous_positions[current_number]
+        current_data.position = previous_positions[layout_bufnr]
         current_data.moving = true
       end
     end

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -52,6 +52,8 @@ end
 --- Calculate the width of the buffers
 --- @return integer sum, integer[] widths
 function Layout.calculate_buffers_width()
+  Layout.buffers = Buffer.hide(state.buffers)
+
   local icons_enabled = options.icons()
   local has_icons = (icons_enabled == true) or (icons_enabled == 'both') or (icons_enabled == 'buffer_number_with_icon')
   local has_numbers = icons_enabled == 'both' or icons_enabled == 'numbers'

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -36,7 +36,8 @@ local SIDES_OF_BUFFER = 2
 --- @field used_width integer
 
 --- @class bufferline.Layout
-local Layout = {}
+--- @field buffers integer[] different from `state.buffers` in that the `hide` option is respected. Only updated when calling `calculate_buffers_width`.
+local Layout = {buffers = {}}
 
 --- The number of characters needed to represent the tabpages.
 --- @return integer width
@@ -61,7 +62,7 @@ function Layout.calculate_buffers_width()
   local sum = 0
   local widths = {}
 
-  for i, bufnr in ipairs(state.buffers) do
+  for i, bufnr in ipairs(Layout.buffers) do
     local buffer_data = state.get_buffer_data(bufnr)
     local buffer_name = buffer_data.name or '[no name]'
 
@@ -107,12 +108,11 @@ function Layout.calculate()
 
   local buffers_width = available_width - tabpages_width
 
-  local buffers_length               = #state.buffers
   local remaining_width              = max(buffers_width - used_width, 0)
-  local remaining_width_per_buffer   = floor(remaining_width / buffers_length)
+  local remaining_width_per_buffer   = floor(remaining_width / #base_widths)
   local remaining_padding_per_buffer = floor(remaining_width_per_buffer / SIDES_OF_BUFFER)
   local padding_width                = max(options.minimum_padding(), min(remaining_padding_per_buffer, options.maximum_padding()))
-  local actual_width                 = used_width + (buffers_length * padding_width * SIDES_OF_BUFFER)
+  local actual_width                 = used_width + (#base_widths * padding_width * SIDES_OF_BUFFER)
 
   return {
     actual_width = actual_width,
@@ -131,7 +131,7 @@ function Layout.calculate_buffers_position_by_buffer_number()
   local layout = Layout.calculate()
   local positions = {}
 
-  for i, buffer_number in ipairs(state.buffers) do
+  for i, buffer_number in ipairs(Layout.buffers) do
     positions[buffer_number] = current_position
     local width = layout.base_widths[i] + (2 * layout.padding_width)
     current_position = current_position + width

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -46,6 +46,12 @@ function options.exclude_name()
   return get('exclude_name', {})
 end
 
+--- @return boolean enabled
+function options.file_icons()
+  local enabled = options.icons()
+  return enabled == true or enabled == 'both' or enabled == 'buffer_number_with_icon'
+end
+
 --- @return {current: nil|boolean, visible: nil|boolean, inactive: nil|boolean} hidden
 function options.hide()
   return get('hide', {})
@@ -84,6 +90,12 @@ end
 --- @return boolean enabled
 function options.icon_custom_colors()
   return get('icon_custom_colors', false)
+end
+
+--- @return boolean enabled
+function options.index_buffers()
+  local enabled = options.icons()
+  return enabled == 'both' or enabled == 'numbers'
 end
 
 --- @return boolean enabled

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -46,6 +46,11 @@ function options.exclude_name()
   return get('exclude_name', {})
 end
 
+--- @return {current: nil|boolean, visible: nil|boolean, inactive: nil|boolean} hidden
+function options.hide()
+  return get('hide', {})
+end
+
 --- @return string icon
 function options.icon_close_tab()
   return get('icon_close_tab', '')

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -943,8 +943,12 @@ function render.update(update_names, refocus)
     return
   end
 
-  local ok, result =
-    xpcall(generate_tabline, debug.traceback, render.get_updated_buffers(update_names), refocus)
+  local ok, result = xpcall(
+    generate_tabline,
+    debug.traceback,
+    Buffer.hide(render.get_updated_buffers(update_names)),
+    refocus
+  )
 
   if not ok then
     render.disable()

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -346,7 +346,11 @@ local function open_buffer_start_animation(layout, bufnr)
   local buffer_data = state.get_buffer_data(bufnr)
   local index = utils.index_of(Layout.buffers, bufnr)
 
-  buffer_data.real_width = Layout.calculate_width(layout.base_widths[index], layout.padding_width)
+  buffer_data.real_width = Layout.calculate_width(
+    layout.base_widths[index] or
+      Layout.calculate_buffer_width(bufnr, #Layout.buffers + 1, options.index_buffers(), options.file_icons()),
+    layout.padding_width
+  )
 
   local target_width = buffer_data.real_width
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -703,7 +703,7 @@ end
 --- @return nil|string syntax
 local function generate_tabline(bufnrs, refocus)
   if options.auto_hide() then
-    if #bufnrs <= 1 then
+    if #bufnrs + #list_tabpages() < 3 then -- 3 because the condition for auto-hiding is 1 visible buffer and 1 tabpage (2).
       if vim.o.showtabline == 2 then
         vim.o.showtabline = 0
       end

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -344,7 +344,7 @@ end
 --- @param layout bufferline.layout.data
 local function open_buffer_start_animation(layout, bufnr)
   local buffer_data = state.get_buffer_data(bufnr)
-  local index = utils.index_of(state.buffers, bufnr)
+  local index = utils.index_of(Layout.buffers, bufnr)
 
   buffer_data.real_width = Layout.calculate_width(layout.base_widths[index], layout.padding_width)
 
@@ -709,6 +709,7 @@ local function generate_tabline(bufnrs, refocus)
       end
       return
     end
+
     if vim.o.showtabline == 0 then
       vim.o.showtabline = 2
     end


### PR DESCRIPTION
Closes #155

Example, which hides inactive buffers:

```lua
require'bufferline'.setup {
  hide = {inactive = true},
}
```