### PR TITLE
fix: ensure `vim.g.bufferline` is always non-`nil` during init

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -167,7 +167,7 @@ function bufferline.setup(user_config)
   )
 
   -- Set the options and watchers for when they are edited
-  vim.g.bufferline = user_config
+  vim.g.bufferline = user_config or vim.empty_dict()
 
   highlight.setup()
   JumpMode.set_letters(options.letters())

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -50,7 +50,13 @@ return {
         vim.log.levels.WARN,
         {title = 'barbar.nvim'}
       )
-      command('let g:bufferline.icons = v:false')
+
+      if type(vim.g.bufferline) == 'table' then
+        command('let g:bufferline.icons = v:false')
+      else
+        vim.g.bufferline = {icons = false}
+      end
+
       return '', ''
     end
 


### PR DESCRIPTION
It seems that it is possible for `nil` values to mess with some of the hard-coded `g:bufferline` accesses.