### PR TITLE
ref(state): use `vim.deprecate` if possible

### DIFF
--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -205,11 +205,16 @@ end
 --- @param text nil|string
 --- @param hl nil|string
 function state.set_offset(width, text, hl)
-  vim.notify(
-    "`require'bufferline.state'.set_offset` is deprecated, use `require'bufferline.api'.set_offset` instead",
-    vim.log.levels.WARN,
-    {title = 'barbar.nvim'}
-  )
+  if vim.deprecate then
+    vim.deprecate('`bufferline.state.set_offset`', '`bufferline.api.set_offset`', '2.0.0', 'barbar.nvim')
+  else
+    vim.notify_once(
+      "`bufferline.state.set_offset` is deprecated, use `bufferline.api.set_offset` instead",
+      vim.log.levels.WARN,
+      {title = 'barbar.nvim'}
+    )
+  end
+
   require'bufferline.api'.set_offset(width, text, hl)
 end
 


### PR DESCRIPTION
In Neovim 0.8, there is a new function `vim.deprecate` which does what we are looking for. I added a gate to ensure that calling this function will not error on older versions of Neovim.