### PR TITLE
redraw tabline when render.update

### DIFF
--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -955,7 +955,7 @@ function render.update(update_names, refocus)
     return
   elseif result ~= last_tabline then
     set_tabline(result)
-    vim.api.nvim_exec('redrawt', false)
+    command('redrawtabline')
   end
 end
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -955,6 +955,7 @@ function render.update(update_names, refocus)
     return
   elseif result ~= last_tabline then
     set_tabline(result)
+    vim.api.nvim_exec('redrawt', false)
   end
 end
 


### PR DESCRIPTION
Not sure if anyone is experiencing this. When `:BufferClose`, the tabline doesn't get updated, and it looks kinda funny.

![Peek 2022-10-15 10-50](https://user-images.githubusercontent.com/9444583/195965983-4471865a-8dc1-4d13-b539-af26211e7eb1.gif)

not sure if there is other way to fix this.

### neovim version

neovim-0.9.0~ubuntu1+git202210141434-81986a734-333b5866f


### This is my setting:
```lua
  local bufferline = require('bufferline')
  bufferline.setup({
    animation = true,
    icon_custom_colors = true,
    maximum_padding = 2,
  })

  vim.api.nvim_set_keymap('n', '<A-,>', ':BufferPrevious<CR>', {silent=true, noremap=true})
  vim.api.nvim_set_keymap('n', '<A-.>', ':BufferNext<CR>', {silent=true, noremap=true})

  vim.api.nvim_set_var('mapleader', ',')
  -- Re-order to previous/next
  vim.api.nvim_set_keymap('n', '<A-Left>', ':BufferMovePrevious<CR>', {silent=true, noremap=true})
  vim.api.nvim_set_keymap('n', '<A-Right>', ':BufferMoveNext<CR>', {silent=true, noremap=true})

  for i = 1,9,1 do
    vim.api.nvim_set_keymap('n', string.format('<Leader>%d', i), string.format(':BufferGoto %d<CR>', i), {silent=true, noremap=true})
  end

  -- Goto buffer in position...
  vim.api.nvim_set_keymap('n', '<Leader>0', ':BufferLast<CR>', {silent=true, noremap=true})
  -- Close buffer
  vim.api.nvim_set_keymap('n', '<Leader><Leader>c', ':BufferClose<CR>', {silent=true, noremap=true})
  vim.api.nvim_set_keymap('n', '<Leader><Leader><Space>', ':BufferCloseAllButCurrent<CR>', {silent=true, noremap=true})
  vim.api.nvim_set_keymap('n', '<Leader><Leader>s', ':BufferPick<CR>', {silent=true, noremap=true})

```