### PR TITLE
fix(render): nvim-session-manager incompatability

### DIFF
--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -452,6 +452,11 @@ function render.enable()
 
   create_autocmd('User', {
     callback = function()
+      local commands = vim.g.session_save_commands
+      if not commands then
+        return
+      end
+
       -- We're allowed to use relative paths for buffers iff there are no tabpages
       -- or windows with a local directory (:tcd and :lcd)
       local use_relative_file_paths = true
@@ -480,7 +485,6 @@ function render.enable()
       end
 
       local bufarr = '{' .. table_concat(bufnames, ',') .. '}'
-      local commands = vim.g.session_save_commands
 
       commands[#commands + 1] = '" barbar.nvim'
       commands[#commands + 1] = "lua require'bufferline.render'.restore_buffers(" .. bufarr .. ")"


### PR DESCRIPTION
Closes #312

Sidenote, but I am not convinced that `xolox/vim-session` is properly integrated by the code in this `User` autocommand. I searched the repo, and apparently the _only_ references to `session_save_commands` on GitHub are from `barbar.nvim`. So where did it even come from?

We might want to look at removing it at some point.