### PR TITLE
feat: option to exclude file extensions from buffer name

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,11 @@ let bufferline.clickable = v:true
 let bufferline.exclude_ft = ['javascript']
 let bufferline.exclude_name = ['package.json']
 
-" Show every buffer
-let bufferline.hide = {'current': v:false, 'inactive': v:false, 'visible': v:false}
+" Hide file extensions
+let bufferline.file_extensions = v:false
+
+" Hide inactive buffers and file extensions. Other options are `current` and `visible`
+let bufferline.hide = {'extensions': v:true, 'inactive': v:true}
 
 " Enable/disable icons
 " if set to 'buffer_number', will show buffer number in the tabline
@@ -307,8 +310,8 @@ require'bufferline'.setup {
   exclude_ft = {'javascript'},
   exclude_name = {'package.json'},
 
-  -- Show every buffer
-  hide = {current = false, inactive = false, visible = false},
+  -- Hide inactive buffers and file extensions. Other options are `current` and `visible`
+  hide = {extensions = true, inactive = true},
 
 
   -- Enable/disable icons

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -312,11 +312,16 @@ Controls if icons are rendered on each tab.
                                                            *g:bufferline.hide*
 `g:bufferline.hide`  table  (default |v:false| for all)
 
-  Sets which buffers are hidden in the bufferline: `current`, `inactive`, and
-  `visible` are possible.
+  Sets which elements are hidden in the bufferline. Possible options are:
+
+  - `current`, which controls the visibility of the current buffer;
+  - `extensions`, which controls the visibility of file extensions;
+  - `inactive`, which controls the visibility of the inactive buffers; and
+  - `visible`, which controls the visibility of visible buffers.
 >
     let g:bufferline.hide = {'current': v:false, 'inactive': v:true}
 <
+
 ==============================================================================
 5. Integrations                                          *barbar-integrations*
 

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -53,8 +53,9 @@ return {
   get_activity = get_activity,
 
   --- @param bufnr integer
+  --- @param hide_extensions boolean? if `true`, exclude the extension of the file
   --- @return string name
-  get_name = function(bufnr)
+  get_name = function(bufnr, hide_extensions)
     --- @type nil|string
     local name = buf_is_valid(bufnr) and buf_get_name(bufnr) or nil
 
@@ -62,7 +63,7 @@ return {
     local maximum_length = options.maximum_length()
 
     if name then
-      name = buf_get_option(bufnr, 'buftype') == 'terminal' and terminalname(name) or utils.basename(name)
+      name = buf_get_option(bufnr, 'buftype') == 'terminal' and terminalname(name) or utils.basename(name, hide_extensions)
     elseif no_name_title ~= nil and no_name_title ~= vim.NIL then
       name = no_name_title
     end

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -2,10 +2,11 @@
 -- get-icon.lua
 --
 
+local buf_get_name = vim.api.nvim_buf_get_name
+local buf_get_option = vim.api.nvim_buf_get_option
 local command = vim.api.nvim_command
 local fnamemodify = vim.fn.fnamemodify
 local hlexists = vim.fn.hlexists
-local matchstr = vim.fn.matchstr
 local notify = vim.notify
 
 --- @type bufferline.utils.hl
@@ -36,11 +37,10 @@ return {
     end
  end,
 
-  --- @param buffer_name string
-  --- @param filetype string
+  --- @param bufnr integer
   --- @param buffer_status "Current"|"Inactive"|"Visible"
   --- @return string icon, string highlight_group
-  get_icon = function(buffer_name, filetype, buffer_status)
+  get_icon = function(bufnr, buffer_status)
     if status == false then
       notify(
         'barbar: bufferline.icons is set to v:true but "nvim-dev-icons" was not found.' ..
@@ -59,23 +59,20 @@ return {
       return '', ''
     end
 
-    local basename
-    local extension
-    local icon_char
-    local icon_hl
+    local basename, extension = '', ''
+    local filetype = buf_get_option(bufnr, 'filetype')
+    local icon_char, icon_hl = '', ''
 
     -- nvim-web-devicon only handles filetype icons, not other types (eg directory)
     -- thus we need to do some work here
     if filetype == 'netrw' or filetype == 'LuaTree' then
-      icon_char = ''
-      icon_hl = 'Directory'
+      icon_char, icon_hl = '', 'Directory'
     else
       if filetype == 'fugitive' or filetype == 'gitcommit' then
-        basename = 'git'
-        extension = 'git'
+        basename, extension = 'git', 'git'
       else
-        basename = fnamemodify(buffer_name, ':t')
-        extension = matchstr(basename, [[\v\.@<=\w+$]], '', '')
+        basename = fnamemodify(buf_get_name(bufnr), ':t')
+        extension = fnamemodify(basename, ':e')
       end
 
       icon_char, icon_hl = web.get_icon(basename, extension, { default = true })

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -6,7 +6,6 @@ local floor = math.floor
 local max = math.max
 local min = math.min
 
-local buf_get_name = vim.api.nvim_buf_get_name
 local buf_get_option = vim.api.nvim_buf_get_option
 local strwidth = vim.api.nvim_strwidth
 local tabpagenr = vim.fn.tabpagenr
@@ -71,7 +70,7 @@ function Layout.calculate_buffer_width(bufnr, index, use_buffer_index, use_file_
     end
 
     if use_file_icon then
-      local file_icon = icons.get_icon(buf_get_name(bufnr), buf_get_option(bufnr, 'filetype'), '')
+      local file_icon = icons.get_icon(bufnr, '')
       width = width + strwidth(file_icon) + 1 -- icon + space after icon
     end
 

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -13,6 +13,12 @@ local function get(key, default)
   end
 end
 
+--- @class bufferline.options.hide
+--- @field current? boolean
+--- @field extensions? boolean
+--- @field inactive? boolean
+--- @field visible? boolean
+
 --- @class bufferline.options
 local options = {}
 
@@ -52,7 +58,7 @@ function options.file_icons()
   return enabled == true or enabled == 'both' or enabled == 'buffer_number_with_icon'
 end
 
---- @return {current: nil|boolean, visible: nil|boolean, inactive: nil|boolean} hidden
+--- @return bufferline.options.hide
 function options.hide()
   return get('hide', {})
 end

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -809,7 +809,7 @@ local function generate_tabline(bufnrs, refocus)
     else
 
       if has_icons then
-        local iconChar, iconHl = icons.get_icon(buffer_name, buf_get_option(bufnr, 'filetype'), status)
+        local iconChar, iconHl = icons.get_icon(bufnr, status)
         local hlName = is_inactive and 'BufferInactive' or iconHl
         iconPrefix = has_icon_custom_colors and hl_tabline('Buffer' .. status .. 'Icon') or hlName and hl_tabline(hlName) or namePrefix
         icon = iconChar .. ' '

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -77,8 +77,9 @@ function state.get_buffer_list()
   local buffers = list_bufs()
   local result = {}
 
-  local exclude_ft   = options.exclude_ft()
+  local exclude_ft = options.exclude_ft()
   local exclude_name = options.exclude_name()
+  local hide_extensions = options.hide().extensions
 
   for _, buffer in ipairs(buffers) do
     if buf_get_option(buffer, 'buflisted') then
@@ -166,10 +167,11 @@ end
 --- Update the names of all buffers in the bufferline.
 function state.update_names()
   local buffer_index_by_name = {}
+  local hide_extensions = options.hide().extensions
 
   -- Compute names
   for i, buffer_n in ipairs(state.buffers) do
-    local name = Buffer.get_name(buffer_n)
+    local name = Buffer.get_name(buffer_n, hide_extensions)
 
     if buffer_index_by_name[name] == nil then
       buffer_index_by_name[name] = i

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -7,6 +7,9 @@ local get_hl_by_name = vim.api.nvim_get_hl_by_name
 local list_slice = vim.list_slice
 local set_hl = vim.api.nvim_set_hl
 
+--- @type bufferline.options
+local options = require'bufferline.options'
+
 --- Generate a color.
 --- @param default integer|string a color name (`string`), GUI hex (`string`), or cterm color code (`integer`).
 --- @param groups string[] the groups to source the color from.
@@ -47,7 +50,13 @@ end
 --- @class bufferline.utils
 return {
   basename = function(path)
-     return fnamemodify(path, ':t')
+    local modifier = ':t'
+
+    if options.hide().extensions then
+      modifier = modifier .. ':r'
+    end
+
+    return fnamemodify(path, modifier)
   end,
 
   --- Return whether element `n` is in a `list.

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -7,9 +7,6 @@ local get_hl_by_name = vim.api.nvim_get_hl_by_name
 local list_slice = vim.list_slice
 local set_hl = vim.api.nvim_set_hl
 
---- @type bufferline.options
-local options = require'bufferline.options'
-
 --- Generate a color.
 --- @param default integer|string a color name (`string`), GUI hex (`string`), or cterm color code (`integer`).
 --- @param groups string[] the groups to source the color from.
@@ -49,10 +46,13 @@ end
 
 --- @class bufferline.utils
 return {
-  basename = function(path)
+  --- @param path string
+  --- @param hide_extension? boolean if `true`, exclude the extension of the file in the basename
+  --- @return string basename
+  basename = function(path, hide_extension)
     local modifier = ':t'
 
-    if options.hide().extensions then
+    if hide_extension then
       modifier = modifier .. ':r'
     end
 
@@ -155,4 +155,3 @@ return {
     return reversed
   end,
 }
-


### PR DESCRIPTION
Hide file extensions with the following option:

```lua
require'bufferline'.setup {hide = {extensions = true}}
```

Disabled by default.

Closes #67. 