### PR TITLE
fix(render): update barbar on BufEnter to show renamed files correctly

### DIFF
--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -499,7 +499,7 @@ function render.enable()
     pattern = 'SessionSavePre',
   })
 
-  create_autocmd('BufNew', {
+  create_autocmd({'BufNew', 'BufEnter'}, {
     callback = function() render.update(true) end,
     group = augroup_bufferline_update,
   })


### PR DESCRIPTION
Update barbar on BufEnter and BufNew.

Previously Barbar only updates on BufNew, so renamed files may not be updated on time (for example, when file is renamed by ranger).

This fixes the issue #319.