### PR TITLE
fix(render): no file names after loading session

### DIFF
--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -499,7 +499,7 @@ function render.enable()
     pattern = 'SessionSavePre',
   })
 
-  create_autocmd({'BufNew', 'BufEnter'}, {
+  create_autocmd({'BufEnter', 'BufNew'}, {
     callback = function() render.update(true) end,
     group = augroup_bufferline_update,
   })
@@ -518,7 +518,7 @@ function render.enable()
     pattern = 'buflisted',
   })
 
-  create_autocmd('WinClosed', {
+  create_autocmd({'SessionLoadPost', 'WinClosed'}, {
     callback = function() schedule(render.update) end,
     group = augroup_bufferline_update,
   })


### PR DESCRIPTION
This fixes the bug that I experienced. Since I wasn't able to reproduce the original bug (possibly because we use different session management tools), I might have to modify this to do:

```lua
  create_autocmd('SessionLoadPost', {
    callback = function() schedule(function() render.update(true) end) end,
    group = augroup_bufferline_update,
  })
```

…depending on your feedback.

Closes #322.