### PR TITLE
fix(doc): use `buffer_number` instead of `buffer_numbers` to avoid inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ let bufferline.exclude_name = ['package.json']
 let bufferline.hide = {'current': v:false, 'inactive': v:false, 'visible': v:false}
 
 " Enable/disable icons
-" if set to 'buffer_number', will show buffer number in the tabline
 " if set to 'numbers', will show buffer index in the tabline
 " if set to 'both', will show buffer index and icons in the tabline
+" if set to 'buffer_number', will show buffer number in the tabline
 " if set to 'buffer_number_with_icon', will show buffer number and icons in the tabline
 let bufferline.icons = v:true
 
@@ -316,6 +316,8 @@ require'bufferline'.setup {
   -- Enable/disable icons
   -- if set to 'numbers', will show buffer index in the tabline
   -- if set to 'both', will show buffer index and icons in the tabline
+  -- if set to 'buffer_number', will show buffer number in the tabline
+  -- if set to 'buffer_number_with_icon', will show buffer number and icons in the tabline
   icons = true,
 
   -- If set, the icon color will follow its corresponding buffer

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -175,9 +175,9 @@ Controls if icons are rendered on each tab.
 
   - If `v:false`, show neither |devicons| nor buffer numbers.
   - If `v:true`, show |devicons| for each buffer's |'filetype'|.
-  - If `"buffer_numbers"`, show the buffer number for current buffer.
   - If `"numbers"`, show the buffer index for current buffer.
   - If `"both"`, show the buffer index and |devicons|.
+  - If `"buffer_number"`, show the buffer number for current buffer.
   - If `"buffer_number_with_icon"`, show the buffer number for current buffer
     and |devicons|.
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -741,6 +741,10 @@ local function generate_tabline(bufnrs, refocus)
   local has_icons = (icons_enabled == true) or (icons_enabled == 'both') or (icons_enabled == 'buffer_number_with_icon')
   local has_icon_custom_colors = options.icon_custom_colors()
   local has_buffer_number = (icons_enabled == 'buffer_number') or (icons_enabled == 'buffer_number_with_icon')
+  if icons_enabled == 'buffer_numbers' then
+    vim.notify_once("`buffer_numbers` is deprecated, please use `buffer_number`", vim.log.levels.WARN, {title = 'barbar.nvim'})
+    has_buffer_number = true
+  end
   local has_numbers = (icons_enabled == 'numbers') or (icons_enabled == 'both')
 
   local layout = Layout.calculate()

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -740,7 +740,7 @@ local function generate_tabline(bufnrs, refocus)
   local has_close = options.closable()
   local has_icons = (icons_enabled == true) or (icons_enabled == 'both') or (icons_enabled == 'buffer_number_with_icon')
   local has_icon_custom_colors = options.icon_custom_colors()
-  local has_buffer_number = (icons_enabled == 'buffer_numbers') or (icons_enabled == 'buffer_number_with_icon')
+  local has_buffer_number = (icons_enabled == 'buffer_number') or (icons_enabled == 'buffer_number_with_icon')
   local has_numbers = (icons_enabled == 'numbers') or (icons_enabled == 'both')
 
   local layout = Layout.calculate()


### PR DESCRIPTION
README.md use `buffer_number`, but the code use `buffer_numbers`.