### PR TITLE
feat: show diagnostic symbols in bufferline

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ let bufferline.closable = v:true
 "  - middle-click: delete buffer
 let bufferline.clickable = v:true
 
+" Enables / disables diagnostic symbols
+" ERROR / WARN / INFO / HINT
+let bufferline.diagnostics = [
+  \ {'enabled': v:true, 'icon': 'ﬀ'},
+  \ {'enabled': v:false},
+  \ {'enabled': v:false},
+  \ {'enabled': v:true},
+\]
+
 " Excludes buffers from the tabline
 let bufferline.exclude_ft = ['javascript']
 let bufferline.exclude_name = ['package.json']
@@ -305,6 +314,21 @@ require'bufferline'.setup {
   --  - left-click: go to buffer
   --  - middle-click: delete buffer
   clickable = true,
+
+  -- Enables / disables diagnostic symbols
+  diagnostics = {
+    -- you can use a list
+    {enabled = true, icon = 'ﬀ'}, -- ERROR
+    {enabled = false}, -- WARN
+    {enabled = false}, -- INFO
+    {enabled = true},  -- HINT
+
+    -- OR `vim.diagnostic.severity`
+    [vim.diagnostic.severity.ERROR] = {enabled = true, icon = 'ﬀ'},
+    [vim.diagnostic.severity.WARN] = {enabled = false},
+    [vim.diagnostic.severity.INFO] = {enabled = false},
+    [vim.diagnostic.severity.HINT] = {enabled = true},
+  },
 
   -- Excludes buffers from the tabline
   exclude_ft = {'javascript'},

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -322,6 +322,27 @@ Controls if icons are rendered on each tab.
     let g:bufferline.hide = {'current': v:false, 'inactive': v:true}
 <
 
+                                                    *g:bufferline.diagnostics*
+`g:bufferline.diagnostics`  list
+
+  Default: >
+  {
+    [vim.diagnostic.severity.ERROR] = {enabled = false, icon = 'Ⓧ '},
+    [vim.diagnostic.severity.HINT] = {enabled = false, icon = '💡'},
+    [vim.diagnostic.severity.INFO] = {enabled = false, icon = 'ⓘ '},
+    [vim.diagnostic.severity.WARN] = {enabled = false, icon = '⚠️ '},
+  }
+<
+
+  Enables or disables showing diagnostics in the bufferline. You can use
+  |vim.diagnostic.severity| or a list (e.g.
+  `{{enabled = true}, {enabled = true},` …`}`) in the order of
+  ERROR/WARN/INFO/HINT.
+
+  - `enabled`, whether this diagnostics of this severity are shown in the
+    bufferline.
+  - `icon`, which controls what icon accompanies the number of diagnostics.
+
 ==============================================================================
 5. Integrations                                          *barbar-integrations*
 

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -55,8 +55,8 @@ local function notify_buffer_not_found(bufnr)
 end
 
 --- Forwards some `order_func` after ensuring that all buffers sorted in the order of pinned first.
---- @param order_func fun(bufnr_a: integer, bufnr_b: integer) accepts `(integer, integer)` params.
---- @return fun(bufnr_a: integer, bufnr_b: integer)
+--- @param order_func fun(bufnr_a: integer, bufnr_b: integer): boolean accepts `(integer, integer)` params.
+--- @return fun(bufnr_a: integer, bufnr_b: integer): boolean
 local function with_pin_order(order_func)
   return function(a, b)
     local a_pinned = state.is_pinned(a)

--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -8,26 +8,42 @@ local icons = require 'bufferline.icons'
 
 -- Setup the highlight groups used by the plugin.
 hl.set_default_link('BufferCurrent', 'BufferDefaultCurrent')
+hl.set_default_link('BufferCurrentERROR', 'BufferDefaultCurrentERROR')
+hl.set_default_link('BufferCurrentHINT', 'BufferDefaultCurrentHINT')
 hl.set_default_link('BufferCurrentIcon', 'BufferCurrent')
 hl.set_default_link('BufferCurrentIndex', 'BufferDefaultCurrentIndex')
+hl.set_default_link('BufferCurrentINFO', 'BufferDefaultCurrentINFO')
 hl.set_default_link('BufferCurrentMod', 'BufferDefaultCurrentMod')
 hl.set_default_link('BufferCurrentSign', 'BufferDefaultCurrentSign')
 hl.set_default_link('BufferCurrentTarget', 'BufferDefaultCurrentTarget')
+hl.set_default_link('BufferCurrentWARN', 'BufferDefaultCurrentWARN')
+
 hl.set_default_link('BufferInactive', 'BufferDefaultInactive')
+hl.set_default_link('BufferInactiveERROR', 'BufferDefaultInactiveERROR')
+hl.set_default_link('BufferInactiveHINT', 'BufferDefaultInactiveHINT')
 hl.set_default_link('BufferInactiveIcon', 'BufferInactive')
 hl.set_default_link('BufferInactiveIndex', 'BufferDefaultInactiveIndex')
+hl.set_default_link('BufferInactiveINFO', 'BufferDefaultInactiveINFO')
 hl.set_default_link('BufferInactiveMod', 'BufferDefaultInactiveMod')
 hl.set_default_link('BufferInactiveSign', 'BufferDefaultInactiveSign')
 hl.set_default_link('BufferInactiveTarget', 'BufferDefaultInactiveTarget')
+hl.set_default_link('BufferInactiveWARN', 'BufferDefaultInactiveWARN')
+
 hl.set_default_link('BufferOffset', 'BufferTabpageFill')
+
 hl.set_default_link('BufferTabpageFill', 'BufferDefaultTabpageFill')
 hl.set_default_link('BufferTabpages', 'BufferDefaultTabpages')
+
 hl.set_default_link('BufferVisible', 'BufferDefaultVisible')
+hl.set_default_link('BufferVisibleERROR', 'BufferDefaultVisibleERROR')
+hl.set_default_link('BufferVisibleHINT', 'BufferDefaultVisibleHINT')
 hl.set_default_link('BufferVisibleIcon', 'BufferVisible')
 hl.set_default_link('BufferVisibleIndex', 'BufferDefaultVisibleIndex')
+hl.set_default_link('BufferVisibleINFO', 'BufferDefaultVisibleINFO')
 hl.set_default_link('BufferVisibleMod', 'BufferDefaultVisibleMod')
 hl.set_default_link('BufferVisibleSign', 'BufferDefaultVisibleSign')
 hl.set_default_link('BufferVisibleTarget', 'BufferDefaultVisibleTarget')
+hl.set_default_link('BufferVisibleWARN', 'BufferDefaultVisibleWARN')
 
 -- NOTE: these should move to `setup_defaults` if the definition stops being a link
 hl.set_default_link('BufferDefaultCurrentIcon', 'BufferDefaultCurrent')
@@ -48,6 +64,11 @@ return {
     local fg_visible  = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
     local fg_inactive = hl.fg_or_default({'TabLineFill'}, '#888888', 102)
 
+    local fg_error = hl.fg_or_default({'ErrorMsg'}, '#A80000', 124)
+    local fg_hint = hl.fg_or_default({'HintMsg'}, '#D5508F', 168)
+    local fg_info = hl.fg_or_default({'InfoMsg'}, '#FFB7B7', 217)
+    local fg_warn = hl.fg_or_default({'WarningMsg'}, '#FF8900', 208)
+
     local fg_modified = hl.fg_or_default({'WarningMsg'}, '#E5AB0E', 178)
     local fg_special  = hl.fg_or_default({'Special'}, '#599eff', 75)
     local fg_subtle = hl.fg_or_default({'NonText', 'Comment'}, '#555555', 240)
@@ -65,22 +86,37 @@ return {
     --        -Sign: the separator between buffers
     --      -Target: letter in buffer-picking mode
     hl.set('BufferDefaultCurrent',        bg_current, fg_current)
+    hl.set('BufferDefaultCurrentERROR',   bg_current, fg_error)
+    hl.set('BufferDefaultCurrentHINT',    bg_current, fg_hint)
     hl.set('BufferDefaultCurrentIndex',   bg_current, fg_special)
+    hl.set('BufferDefaultCurrentINFO',    bg_current, fg_info)
     hl.set('BufferDefaultCurrentMod',     bg_current, fg_modified)
     hl.set('BufferDefaultCurrentSign',    bg_current, fg_special)
     hl.set('BufferDefaultCurrentTarget',  bg_current, fg_target, true)
+    hl.set('BufferDefaultCurrentWARN',    bg_current, fg_warn)
+
     hl.set('BufferDefaultInactive',       bg_inactive, fg_inactive)
+    hl.set('BufferDefaultInactiveERROR',  bg_inactive, fg_error)
+    hl.set('BufferDefaultInactiveHINT',   bg_inactive, fg_hint)
     hl.set('BufferDefaultInactiveIndex',  bg_inactive, fg_subtle)
+    hl.set('BufferDefaultInactiveINFO',   bg_inactive, fg_info)
     hl.set('BufferDefaultInactiveMod',    bg_inactive, fg_modified)
     hl.set('BufferDefaultInactiveSign',   bg_inactive, fg_subtle)
     hl.set('BufferDefaultInactiveTarget', bg_inactive, fg_target, true)
+    hl.set('BufferDefaultInactiveWARN',   bg_inactive, fg_warn)
+
     hl.set('BufferDefaultTabpageFill',    bg_inactive, fg_inactive)
     hl.set('BufferDefaultTabpages',       bg_inactive, fg_special, true)
+
     hl.set('BufferDefaultVisible',        bg_visible, fg_visible)
+    hl.set('BufferDefaultVisibleERROR',   bg_visible, fg_error)
+    hl.set('BufferDefaultVisibleHINT',    bg_visible, fg_hint)
     hl.set('BufferDefaultVisibleIndex',   bg_visible, fg_visible)
+    hl.set('BufferDefaultVisibleINFO',    bg_visible, fg_info)
     hl.set('BufferDefaultVisibleMod',     bg_visible, fg_modified)
     hl.set('BufferDefaultVisibleSign',    bg_visible, fg_visible)
     hl.set('BufferDefaultVisibleTarget',  bg_visible, fg_target, true)
+    hl.set('BufferDefaultVisibleWARN',    bg_visible, fg_warn)
 
     icons.set_highlights()
   end

--- a/lua/bufferline/jump_mode.lua
+++ b/lua/bufferline/jump_mode.lua
@@ -20,11 +20,11 @@ local options = require'bufferline.options'
 local letters = {}
 
 --- @class bufferline.JumpMode
---- @field private buffer_by_letter {[string]: integer} a bi-directional map of buffer integers and their letters.
+--- @field buffer_by_letter {[string]: integer} a bi-directional map of buffer integers and their letters.
 --- @field private index_by_letter {[string]: integer} `letters` in the order they were provided
 --- @field private letter_by_buffer {[integer]: string} a bi-directional map of buffer integers and their letters.
 --- @field private letter_status {[integer]: boolean}
---- @field private reinitialize boolean whether an `initialize_indexes` operation has been queued.
+--- @field reinitialize boolean whether an `initialize_indexes` operation has been queued.
 local JumpMode = {}
 
 --- Reset the module to a valid default state

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -51,10 +51,11 @@ end
 
 --- @param bufnr integer the buffer to calculate the width of.
 --- @param index integer the buffer's numerical index
+--- @param diagnostics bufferline.options.diagnostics
 --- @param use_buffer_index boolean whether the buffer index is rendered
 --- @param use_file_icon boolean whether an filetype icon is rendered
 --- @return integer width
-function Layout.calculate_buffer_width(bufnr, index, use_buffer_index, use_file_icon)
+function Layout.calculate_buffer_width(bufnr, index, diagnostics, use_buffer_index, use_file_icon)
   local buffer_data = state.get_buffer_data(bufnr)
   local buffer_name = buffer_data.name or '[no name]'
   local width
@@ -70,9 +71,14 @@ function Layout.calculate_buffer_width(bufnr, index, use_buffer_index, use_file_
     end
 
     if use_file_icon then
+      --- @diagnostic disable-next-line:param-type-mismatch
       local file_icon = icons.get_icon(bufnr, '')
       width = width + strwidth(file_icon) + 1 -- icon + space after icon
     end
+
+    Buffer.for_each_counted_enabled_diagnostic(bufnr, diagnostics, function(c, d, _)
+      width = width + 1 + strwidth(d.icon) + #tostring(c) -- space before icon + icon + diagnostic count
+    end)
 
     local is_pinned = state.is_pinned(bufnr)
     if options.closable() or is_pinned then
@@ -90,14 +96,15 @@ end
 function Layout.calculate_buffers_width()
   Layout.buffers = Buffer.hide(state.buffers)
 
-  local use_file_icons = options.file_icons()
+  local diagnostics = options.diagnostics()
   local use_buffer_index = options.index_buffers()
+  local use_file_icons = options.file_icons()
 
   local sum = 0
   local widths = {}
 
   for i, bufnr in ipairs(Layout.buffers) do
-    local width = Layout.calculate_buffer_width(bufnr, i, use_buffer_index, use_file_icons)
+    local width = Layout.calculate_buffer_width(bufnr, i, diagnostics, use_buffer_index, use_file_icons)
     sum = sum + width
     widths[#widths + 1] = width
   end

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -63,8 +63,8 @@ function Layout.calculate_buffer_width(bufnr, index, diagnostics, use_buffer_ind
   if buffer_data.closing then
     width = buffer_data.real_width
   else
-    width = strwidth(buffer_name) + 1 + -- name + space after name
-      strwidth(options['icon_separator_' .. (Buffer.get_activity(bufnr) > 1 and '' or 'in') .. 'active']()) -- separator
+    local activity = Buffer.get_activity(bufnr) > 1 and 'active' or 'inactive'
+    width = strwidth(options['icon_separator_' .. activity]()) + strwidth(buffer_name) -- separator + name
 
     if use_buffer_index then
       width = width + #tostring(index) + 1 -- buffer-index + space after buffer-index

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -1,3 +1,8 @@
+local ERROR = vim.diagnostic.severity.ERROR
+local HINT = vim.diagnostic.severity.HINT
+local INFO = vim.diagnostic.severity.INFO
+local WARN = vim.diagnostic.severity.WARN
+
 --- Retrieve some value under `key` from `g:bufferline`, or return a `default` if none was present.
 --- PERF: this implementation was profiled be an improvement over `vim.g.bufferline and vim.g.bufferline[key] or default`
 --- @generic T
@@ -12,6 +17,22 @@ local function get(key, default)
     return value
   end
 end
+
+--- @class bufferline.options.diagnostics.severity
+--- @field enabled boolean
+--- @field icon string
+
+--- @class bufferline.options.diagnostics
+--- @field [1] bufferline.options.diagnostics.severity
+--- @field [2] bufferline.options.diagnostics.severity
+--- @field [3] bufferline.options.diagnostics.severity
+--- @field [4] bufferline.options.diagnostics.severity
+local DEFAULT_DIAGNOSTICS = {
+  [ERROR] = {enabled = false, icon = 'Ⓧ '},
+  [HINT] = {enabled = false, icon = '💡'},
+  [INFO] = {enabled = false, icon = 'ⓘ '},
+  [WARN] = {enabled = false, icon = '⚠️ '},
+}
 
 --- @class bufferline.options.hide
 --- @field current? boolean
@@ -40,6 +61,11 @@ end
 --- @return boolean enabled
 function options.closable()
   return get('closable', true)
+end
+
+--- @return bufferline.options.diagnostics
+function options.diagnostics()
+  return vim.tbl_deep_extend('keep', get('diagnostics', {}), DEFAULT_DIAGNOSTICS)
 end
 
 --- @return string[] excluded

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -876,7 +876,6 @@ local function generate_tabline(bufnrs, refocus)
 
     vim.list_extend(item.groups, {
       {hl = '',          text = padding},
-      {hl = '',          text = ' '},
       {hl = closePrefix, text = close},
     })
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -32,6 +32,7 @@ local notify = vim.notify
 local schedule = vim.schedule
 local set_current_buf = vim.api.nvim_set_current_buf
 local set_current_win = vim.api.nvim_set_current_win
+local severity = vim.diagnostic.severity
 local strcharpart = vim.fn.strcharpart
 local strwidth = vim.api.nvim_strwidth
 local tabpage_list_wins = vim.api.nvim_tabpage_list_wins
@@ -348,7 +349,7 @@ local function open_buffer_start_animation(layout, bufnr)
 
   buffer_data.real_width = Layout.calculate_width(
     layout.base_widths[index] or
-      Layout.calculate_buffer_width(bufnr, #Layout.buffers + 1, options.index_buffers(), options.file_icons()),
+      Layout.calculate_buffer_width(bufnr, #Layout.buffers + 1, options.diagnostics(), options.index_buffers(), options.file_icons()),
     layout.padding_width
   )
 
@@ -505,7 +506,14 @@ function render.enable()
   })
 
   create_autocmd(
-    {'BufEnter', 'BufWinEnter', 'BufWinLeave', 'BufWritePost', 'SessionLoadPost', 'TabEnter', 'VimResized', 'WinEnter', 'WinLeave'},
+    {
+      'BufEnter', 'BufWinEnter', 'BufWinLeave', 'BufWritePost',
+      'CursorHold', 'CursorHoldI',
+      'SessionLoadPost',
+      'TabEnter',
+      'VimResized',
+      'WinEnter', 'WinLeave',
+    },
     {
       callback = function() render.update() end,
       group = augroup_bufferline_update,
@@ -734,12 +742,13 @@ local function generate_tabline(bufnrs, refocus)
     end
   end
 
+  local click_enabled = has('tablineat') and options.clickable()
+  local diagnostics = options.diagnostics()
+  local has_close = options.closable()
+  local has_icon_custom_colors = options.icon_custom_colors()
   local icons_enabled = options.icons()
 
-  local click_enabled = has('tablineat') and options.clickable()
-  local has_close = options.closable()
   local has_icons = (icons_enabled == true) or (icons_enabled == 'both') or (icons_enabled == 'buffer_number_with_icon')
-  local has_icon_custom_colors = options.icon_custom_colors()
   local has_buffer_number = (icons_enabled == 'buffer_numbers') or (icons_enabled == 'buffer_number_with_icon')
   local has_numbers = (icons_enabled == 'numbers') or (icons_enabled == 'both')
 
@@ -855,11 +864,21 @@ local function generate_tabline(bufnrs, refocus)
         {hl = clickable .. iconPrefix,      text = icon},
         {hl = jumpLetterPrefix,             text = jumpLetter},
         {hl = clickable .. namePrefix,      text = name},
-        {hl = '',                           text = padding},
-        {hl = '',                           text = ' '},
-        {hl = closePrefix,                  text = close},
       }
     }
+
+    Buffer.for_each_counted_enabled_diagnostic(bufnr, diagnostics, function(c, d, s)
+      table_insert(item.groups, {
+        hl = hl_tabline('Buffer' .. status .. severity[s]),
+        text = ' ' .. d.icon .. c,
+      })
+    end)
+
+    vim.list_extend(item.groups, {
+      {hl = '',          text = padding},
+      {hl = '',          text = ' '},
+      {hl = closePrefix, text = close},
+    })
 
     if is_current and refocus ~= false then
       current_buffer_index = i

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -85,8 +85,7 @@ function state.get_buffer_list()
     if buf_get_option(buffer, 'buflisted') then
       local ft = buf_get_option(buffer, 'filetype')
       if not utils.has(exclude_ft, ft) then
-        local fullname = buf_get_name(buffer)
-        local name = utils.basename(fullname)
+        local name = utils.basename(buf_get_name(buffer), hide_extensions)
         if not utils.has(exclude_name, name) then
           result[#result + 1] = buffer
         end

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -6,6 +6,7 @@ local fnamemodify = vim.fn.fnamemodify
 local get_hl_by_name = vim.api.nvim_get_hl_by_name
 local list_slice = vim.list_slice
 local set_hl = vim.api.nvim_set_hl
+local hlexists = vim.fn.hlexists
 
 --- Generate a color.
 --- @param default integer|string a color name (`string`), GUI hex (`string`), or cterm color code (`integer`).
@@ -15,9 +16,11 @@ local set_hl = vim.api.nvim_set_hl
 --- @return integer|string color
 local function attribute_or_default(groups, index, default, guicolors)
   for _, group in ipairs(groups) do
-    local hl = get_hl_by_name(group, guicolors)
-    if hl[index] then
-      return guicolors and ('#%06x'):format(hl[index]) or hl[index]
+    if hlexists(group) > 0 then
+      local hl = get_hl_by_name(group, guicolors)
+      if hl[index] then
+        return guicolors and ('#%06x'):format(hl[index]) or hl[index]
+      end
     end
   end
 


### PR DESCRIPTION
This feature is opt-_in_ right now, but I'm open to making it opt-out.

![cap](https://user-images.githubusercontent.com/36409591/203146058-60594f42-4d4c-4cba-b5a7-891615fd08c3.png)

Closes #97 

---

You can enable it two ways. First, by specifying the `vim.diagnostic.severity`:

```lua
require'bufferline'.setup {
  diagnostics = {
    [vim.diagnostic.severity.ERROR] = {enabled = true, icon = '⋄'},
    [vim.diagnostic.severity.HINT] = {enabled = true},
    [vim.diagnostic.severity.INFO] = {enabled = true},
    [vim.diagnostic.severity.WARN] = {enabled = true},
  },
}
```

Second, by using the `vim.diagnostic.severity`'s index:

```lua
require'bufferline'.setup {
  diagnostics = {
    {enabled = true, icon = '⋄'}, -- ERROR
    {enabled = true}, -- WARN
    {enabled = true}, -- INFO
    {enabled = true}, -- HINT
  },
}
```

---

To do:

* [x] Figure out a better default highlight groups for HINT and INFO
* [x] Fix layout calculation when symbols are present
* [x] Write docs