### PR TITLE
feat: highlight alternate buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ let bufferline.auto_hide = v:false
 " Enable/disable current/total tabpages indicator (top right corner)
 let bufferline.tabpages = v:true
 
+" Enable/disable distinguishing between certain types of buffers
+let bufferline.categories = {'alternate': v:false, 'visible': v:true},
+
 " Enable/disable close button
 let bufferline.closable = v:true
 
@@ -238,10 +241,7 @@ let bufferline.diagnostics = [
 let bufferline.exclude_ft = ['javascript']
 let bufferline.exclude_name = ['package.json']
 
-" Hide file extensions
-let bufferline.file_extensions = v:false
-
-" Hide inactive buffers and file extensions. Other options are `current` and `visible`
+" Hide inactive buffers and file extensions. Other options are `alternate`, `current`, and `visible`.
 let bufferline.hide = {'extensions': v:true, 'inactive': v:true}
 
 " Enable/disable icons
@@ -307,6 +307,9 @@ require'bufferline'.setup {
   -- Enable/disable current/total tabpages indicator (top right corner)
   tabpages = true,
 
+  -- Enable/disable distinguishing between certain types of buffers
+  categories = {alternate = false, visible = true},
+
   -- Enable/disable close button
   closable = true,
 
@@ -334,7 +337,7 @@ require'bufferline'.setup {
   exclude_ft = {'javascript'},
   exclude_name = {'package.json'},
 
-  -- Hide inactive buffers and file extensions. Other options are `current` and `visible`
+  -- Hide inactive buffers and file extensions. Other options are `alternate`, `current`, and `visible`.
   hide = {extensions = true, inactive = true},
 
 

--- a/README.md
+++ b/README.md
@@ -217,9 +217,6 @@ let bufferline.auto_hide = v:false
 " Enable/disable current/total tabpages indicator (top right corner)
 let bufferline.tabpages = v:true
 
-" Enable/disable distinguishing between certain types of buffers
-let bufferline.categories = {'alternate': v:false, 'visible': v:true},
-
 " Enable/disable close button
 let bufferline.closable = v:true
 
@@ -243,6 +240,12 @@ let bufferline.exclude_name = ['package.json']
 
 " Hide inactive buffers and file extensions. Other options are `alternate`, `current`, and `visible`.
 let bufferline.hide = {'extensions': v:true, 'inactive': v:true}
+
+" Disable highlighting alternate buffers
+let bufferline.highlight_alternate = v:false
+
+" Enable highlighting visible buffers
+let bufferline.highlight_visible = v:true
 
 " Enable/disable icons
 " if set to 'buffer_number', will show buffer number in the tabline
@@ -307,9 +310,6 @@ require'bufferline'.setup {
   -- Enable/disable current/total tabpages indicator (top right corner)
   tabpages = true,
 
-  -- Enable/disable distinguishing between certain types of buffers
-  categories = {alternate = false, visible = true},
-
   -- Enable/disable close button
   closable = true,
 
@@ -340,6 +340,11 @@ require'bufferline'.setup {
   -- Hide inactive buffers and file extensions. Other options are `alternate`, `current`, and `visible`.
   hide = {extensions = true, inactive = true},
 
+  -- Disable highlighting alternate buffers
+  highlight_alternate = false,
+
+  -- Enable highlighting visible buffers
+  highlight_visible = true,
 
   -- Enable/disable icons
   -- if set to 'numbers', will show buffer index in the tabline

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -314,10 +314,13 @@ Controls if icons are rendered on each tab.
 
   Sets which elements are hidden in the bufferline. Possible options are:
 
+  - `alternate`, which controls the visibility of the alternate buffer
+    (`g:bufferline.highlight.alternate` must be |v:true|);
   - `current`, which controls the visibility of the current buffer;
   - `extensions`, which controls the visibility of file extensions;
   - `inactive`, which controls the visibility of the inactive buffers; and
-  - `visible`, which controls the visibility of visible buffers.
+  - `visible`, which controls the visibility of visible buffers
+    (`g:bufferline.highlight.visible` must be |v:true|).
 >
     let g:bufferline.hide = {'current': v:false, 'inactive': v:true}
 <
@@ -342,6 +345,18 @@ Controls if icons are rendered on each tab.
   - `enabled`, whether this diagnostics of this severity are shown in the
     bufferline.
   - `icon`, which controls what icon accompanies the number of diagnostics.
+
+                                                      *g:bufferline.highlight*
+`g:bufferline.highlight`  table  (default |v:false| for `alternate`, and
+                                        |v:true| for `visible`)
+
+  Enables highlighting certain types of buffers.
+
+  - `alternate`, which controls highlighting the alternate buffer; and
+  - `visible`, which controls the highlighting visible buffers.
+>
+    let g:bufferline.highlight = {'alternate': v:true, 'visible': v:false}
+<
 
 ==============================================================================
 5. Integrations                                          *barbar-integrations*

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -346,16 +346,20 @@ Controls if icons are rendered on each tab.
     bufferline.
   - `icon`, which controls what icon accompanies the number of diagnostics.
 
-                                                      *g:bufferline.highlight*
-`g:bufferline.highlight`  table  (default |v:false| for `alternate`, and
-                                        |v:true| for `visible`)
+                                            *g:bufferline.highlight_alternate*
+`g:bufferline.highlight_alternate`  boolean  (default |v:false|)
 
-  Enables highlighting certain types of buffers.
-
-  - `alternate`, which controls highlighting the alternate buffer; and
-  - `visible`, which controls the highlighting visible buffers.
+  Enables highlighting of alternate buffers.
 >
-    let g:bufferline.highlight = {'alternate': v:true, 'visible': v:false}
+    let g:bufferline.highlight_alternate = v:true
+<
+
+                                              *g:bufferline.highlight_visible*
+`g:bufferline.highlight_visible`  boolean  (default |v:true|)
+
+  Enables highlighting of visible buffers.
+>
+    let g:bufferline.highlight_visible = v:true
 <
 
 ==============================================================================

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -47,13 +47,11 @@ end
 --- @param buffer_number integer
 --- @return bufferline.buffer.activity # whether `bufnr` is inactive, visible, the alternate file, or currently selected (in that order).
 local function get_activity(buffer_number)
-  local highlight = options.highlight()
-
   if get_current_buf() == buffer_number then
     return 4
-  elseif highlight.alternate and bufnr('#') == buffer_number then
+  elseif options.highlight_alternate() and bufnr('#') == buffer_number then
     return 3
-  elseif highlight.visible and bufwinnr(buffer_number) ~= -1 then
+  elseif options.highlight_visible() and bufwinnr(buffer_number) ~= -1 then
     return 2
   end
 

--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -7,6 +7,17 @@ local hl = require'bufferline.utils'.hl
 local icons = require 'bufferline.icons'
 
 -- Setup the highlight groups used by the plugin.
+hl.set_default_link('BufferAlternate', 'BufferDefaultAlternate')
+hl.set_default_link('BufferAlternateERROR', 'BufferDefaultAlternateERROR')
+hl.set_default_link('BufferAlternateHINT', 'BufferDefaultAlternateHINT')
+hl.set_default_link('BufferAlternateIcon', 'BufferAlternate')
+hl.set_default_link('BufferAlternateIndex', 'BufferDefaultAlternateIndex')
+hl.set_default_link('BufferAlternateINFO', 'BufferDefaultAlternateINFO')
+hl.set_default_link('BufferAlternateMod', 'BufferDefaultAlternateMod')
+hl.set_default_link('BufferAlternateSign', 'BufferDefaultAlternateSign')
+hl.set_default_link('BufferAlternateTarget', 'BufferDefaultAlternateTarget')
+hl.set_default_link('BufferAlternateWARN', 'BufferDefaultAlternateWARN')
+
 hl.set_default_link('BufferCurrent', 'BufferDefaultCurrent')
 hl.set_default_link('BufferCurrentERROR', 'BufferDefaultCurrentERROR')
 hl.set_default_link('BufferCurrentHINT', 'BufferDefaultCurrentHINT')
@@ -60,9 +71,10 @@ return {
     local fg_target = {cterm = 'red'}
     fg_target.gui = fg_target.cterm
 
-    local fg_current  = hl.fg_or_default({'Normal'}, '#efefef', 255)
-    local fg_visible  = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
+    local fg_alternate = hl.fg_or_default({'TabLineFill'}, '#ead0a0', 223)
+    local fg_current = hl.fg_or_default({'Normal'}, '#efefef', 255)
     local fg_inactive = hl.fg_or_default({'TabLineFill'}, '#888888', 102)
+    local fg_visible = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
 
     local fg_error = hl.fg_or_default({'ErrorMsg'}, '#A80000', 124)
     local fg_hint = hl.fg_or_default({'HintMsg'}, '#D5508F', 168)
@@ -70,13 +82,15 @@ return {
     local fg_warn = hl.fg_or_default({'WarningMsg'}, '#FF8900', 208)
 
     local fg_modified = hl.fg_or_default({'WarningMsg'}, '#E5AB0E', 178)
-    local fg_special  = hl.fg_or_default({'Special'}, '#599eff', 75)
+    local fg_special = hl.fg_or_default({'Special'}, '#599eff', 75)
     local fg_subtle = hl.fg_or_default({'NonText', 'Comment'}, '#555555', 240)
 
-    local bg_current  = hl.bg_or_default({'Normal'}, 'none')
-    local bg_visible  = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
+    local bg_alternate = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
+    local bg_current = hl.bg_or_default({'Normal'}, 'none')
+    local bg_visible = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
     local bg_inactive = hl.bg_or_default({'TabLineFill', 'StatusLine'}, 'none')
 
+    --    Alternate: alternate buffer
     --      Current: current buffer
     --      Visible: visible but not current buffer
     --     Inactive: invisible but not current buffer
@@ -85,6 +99,16 @@ return {
     --         -Mod: when modified
     --        -Sign: the separator between buffers
     --      -Target: letter in buffer-picking mode
+    hl.set('BufferDefaultAlternate',        bg_alternate, fg_alternate)
+    hl.set('BufferDefaultAlternateERROR',   bg_alternate, fg_error)
+    hl.set('BufferDefaultAlternateHINT',    bg_alternate, fg_hint)
+    hl.set('BufferDefaultAlternateIndex',   bg_alternate, fg_special)
+    hl.set('BufferDefaultAlternateINFO',    bg_alternate, fg_info)
+    hl.set('BufferDefaultAlternateMod',     bg_alternate, fg_modified)
+    hl.set('BufferDefaultAlternateSign',    bg_alternate, fg_special)
+    hl.set('BufferDefaultAlternateTarget',  bg_alternate, fg_target, true)
+    hl.set('BufferDefaultAlternateWARN',    bg_alternate, fg_warn)
+
     hl.set('BufferDefaultCurrent',        bg_current, fg_current)
     hl.set('BufferDefaultCurrentERROR',   bg_current, fg_error)
     hl.set('BufferDefaultCurrentHINT',    bg_current, fg_hint)

--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -69,8 +69,6 @@ hl.set_default_link('BufferDefaultOffset', 'BufferDefaultTabpageFill')
 return {
   --- Setup the highlight groups for this plugin.
   setup = function()
-    local highlight = options.highlight()
-
     local fg_current = hl.fg_or_default({'Normal'}, '#efefef', 255)
     local fg_inactive = hl.fg_or_default({'TabLineFill'}, '#888888', 102)
     --- @type barbar.utils.hl.group
@@ -98,7 +96,7 @@ return {
     --         -Mod: when modified
     --        -Sign: the separator between buffers
     --      -Target: letter in buffer-picking mode
-    if highlight.alternate then
+    if options.highlight_alternate() then
       local fg_alternate = hl.fg_or_default({'TabLineFill'}, '#ead0a0', 223)
       local bg_alternate = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
 
@@ -136,7 +134,7 @@ return {
     hl.set('BufferDefaultTabpageFill',    bg_inactive, fg_inactive)
     hl.set('BufferDefaultTabpages',       bg_inactive, fg_special, true)
 
-    if highlight.visible then
+    if options.highlight_visible() then
       local fg_visible = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
       local bg_visible = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
 

--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -6,6 +6,9 @@ local hl = require'bufferline.utils'.hl
 --- @type bufferline.icons
 local icons = require 'bufferline.icons'
 
+--- @type bufferline.options
+local options = require 'bufferline.options'
+
 -- Setup the highlight groups used by the plugin.
 hl.set_default_link('BufferAlternate', 'BufferDefaultAlternate')
 hl.set_default_link('BufferAlternateERROR', 'BufferDefaultAlternateERROR')
@@ -66,15 +69,13 @@ hl.set_default_link('BufferDefaultOffset', 'BufferDefaultTabpageFill')
 return {
   --- Setup the highlight groups for this plugin.
   setup = function()
+    local highlight = options.highlight()
 
+    local fg_current = hl.fg_or_default({'Normal'}, '#efefef', 255)
+    local fg_inactive = hl.fg_or_default({'TabLineFill'}, '#888888', 102)
     --- @type barbar.utils.hl.group
     local fg_target = {cterm = 'red'}
     fg_target.gui = fg_target.cterm
-
-    local fg_alternate = hl.fg_or_default({'TabLineFill'}, '#ead0a0', 223)
-    local fg_current = hl.fg_or_default({'Normal'}, '#efefef', 255)
-    local fg_inactive = hl.fg_or_default({'TabLineFill'}, '#888888', 102)
-    local fg_visible = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
 
     local fg_error = hl.fg_or_default({'ErrorMsg'}, '#A80000', 124)
     local fg_hint = hl.fg_or_default({'HintMsg'}, '#D5508F', 168)
@@ -85,9 +86,7 @@ return {
     local fg_special = hl.fg_or_default({'Special'}, '#599eff', 75)
     local fg_subtle = hl.fg_or_default({'NonText', 'Comment'}, '#555555', 240)
 
-    local bg_alternate = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
     local bg_current = hl.bg_or_default({'Normal'}, 'none')
-    local bg_visible = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
     local bg_inactive = hl.bg_or_default({'TabLineFill', 'StatusLine'}, 'none')
 
     --    Alternate: alternate buffer
@@ -99,15 +98,20 @@ return {
     --         -Mod: when modified
     --        -Sign: the separator between buffers
     --      -Target: letter in buffer-picking mode
-    hl.set('BufferDefaultAlternate',        bg_alternate, fg_alternate)
-    hl.set('BufferDefaultAlternateERROR',   bg_alternate, fg_error)
-    hl.set('BufferDefaultAlternateHINT',    bg_alternate, fg_hint)
-    hl.set('BufferDefaultAlternateIndex',   bg_alternate, fg_special)
-    hl.set('BufferDefaultAlternateINFO',    bg_alternate, fg_info)
-    hl.set('BufferDefaultAlternateMod',     bg_alternate, fg_modified)
-    hl.set('BufferDefaultAlternateSign',    bg_alternate, fg_special)
-    hl.set('BufferDefaultAlternateTarget',  bg_alternate, fg_target, true)
-    hl.set('BufferDefaultAlternateWARN',    bg_alternate, fg_warn)
+    if highlight.alternate then
+      local fg_alternate = hl.fg_or_default({'TabLineFill'}, '#ead0a0', 223)
+      local bg_alternate = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
+
+      hl.set('BufferDefaultAlternate',        bg_alternate, fg_alternate)
+      hl.set('BufferDefaultAlternateERROR',   bg_alternate, fg_error)
+      hl.set('BufferDefaultAlternateHINT',    bg_alternate, fg_hint)
+      hl.set('BufferDefaultAlternateIndex',   bg_alternate, fg_special)
+      hl.set('BufferDefaultAlternateINFO',    bg_alternate, fg_info)
+      hl.set('BufferDefaultAlternateMod',     bg_alternate, fg_modified)
+      hl.set('BufferDefaultAlternateSign',    bg_alternate, fg_special)
+      hl.set('BufferDefaultAlternateTarget',  bg_alternate, fg_target, true)
+      hl.set('BufferDefaultAlternateWARN',    bg_alternate, fg_warn)
+    end
 
     hl.set('BufferDefaultCurrent',        bg_current, fg_current)
     hl.set('BufferDefaultCurrentERROR',   bg_current, fg_error)
@@ -132,15 +136,20 @@ return {
     hl.set('BufferDefaultTabpageFill',    bg_inactive, fg_inactive)
     hl.set('BufferDefaultTabpages',       bg_inactive, fg_special, true)
 
-    hl.set('BufferDefaultVisible',        bg_visible, fg_visible)
-    hl.set('BufferDefaultVisibleERROR',   bg_visible, fg_error)
-    hl.set('BufferDefaultVisibleHINT',    bg_visible, fg_hint)
-    hl.set('BufferDefaultVisibleIndex',   bg_visible, fg_visible)
-    hl.set('BufferDefaultVisibleINFO',    bg_visible, fg_info)
-    hl.set('BufferDefaultVisibleMod',     bg_visible, fg_modified)
-    hl.set('BufferDefaultVisibleSign',    bg_visible, fg_visible)
-    hl.set('BufferDefaultVisibleTarget',  bg_visible, fg_target, true)
-    hl.set('BufferDefaultVisibleWARN',    bg_visible, fg_warn)
+    if highlight.visible then
+      local fg_visible = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
+      local bg_visible = hl.bg_or_default({'TabLineSel', 'Normal'}, 'none')
+
+      hl.set('BufferDefaultVisible',        bg_visible, fg_visible)
+      hl.set('BufferDefaultVisibleERROR',   bg_visible, fg_error)
+      hl.set('BufferDefaultVisibleHINT',    bg_visible, fg_hint)
+      hl.set('BufferDefaultVisibleIndex',   bg_visible, fg_visible)
+      hl.set('BufferDefaultVisibleINFO',    bg_visible, fg_info)
+      hl.set('BufferDefaultVisibleMod',     bg_visible, fg_modified)
+      hl.set('BufferDefaultVisibleSign',    bg_visible, fg_visible)
+      hl.set('BufferDefaultVisibleTarget',  bg_visible, fg_target, true)
+      hl.set('BufferDefaultVisibleWARN',    bg_visible, fg_warn)
+    end
 
     icons.set_highlights()
   end

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -1,6 +1,8 @@
 local ERROR = vim.diagnostic.severity.ERROR
 local HINT = vim.diagnostic.severity.HINT
 local INFO = vim.diagnostic.severity.INFO
+local tbl_deep_extend = vim.tbl_deep_extend
+local tbl_extend = vim.tbl_extend
 local WARN = vim.diagnostic.severity.WARN
 
 --- Retrieve some value under `key` from `g:bufferline`, or return a `default` if none was present.
@@ -17,6 +19,10 @@ local function get(key, default)
     return value
   end
 end
+
+
+--- @class bufferline.options.highlight
+local DEFAULT_HIGHLIGHTS = {alternate = false, visible = true}
 
 --- @class bufferline.options.diagnostics.severity
 --- @field enabled boolean
@@ -35,6 +41,7 @@ local DEFAULT_DIAGNOSTICS = {
 }
 
 --- @class bufferline.options.hide
+--- @field alternate? boolean
 --- @field current? boolean
 --- @field extensions? boolean
 --- @field inactive? boolean
@@ -65,7 +72,7 @@ end
 
 --- @return bufferline.options.diagnostics
 function options.diagnostics()
-  return vim.tbl_deep_extend('keep', get('diagnostics', {}), DEFAULT_DIAGNOSTICS)
+  return tbl_deep_extend('keep', get('diagnostics', {}), DEFAULT_DIAGNOSTICS)
 end
 
 --- @return string[] excluded
@@ -87,6 +94,11 @@ end
 --- @return bufferline.options.hide
 function options.hide()
   return get('hide', {})
+end
+
+--- @return bufferline.options.highlight # `true` in a field enables distinguishing buffers of a particular kind
+function options.highlight()
+  return tbl_extend('keep', get('categories', {}), DEFAULT_HIGHLIGHTS)
 end
 
 --- @return string icon
@@ -111,6 +123,11 @@ end
 
 --- @return string icon
 function options.icon_separator_inactive()
+  return get('icon_separator_inactive', '▎')
+end
+
+--- @return string icon
+function options.icon_separator_visible()
   return get('icon_separator_inactive', '▎')
 end
 

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -2,7 +2,6 @@ local ERROR = vim.diagnostic.severity.ERROR
 local HINT = vim.diagnostic.severity.HINT
 local INFO = vim.diagnostic.severity.INFO
 local tbl_deep_extend = vim.tbl_deep_extend
-local tbl_extend = vim.tbl_extend
 local WARN = vim.diagnostic.severity.WARN
 
 --- Retrieve some value under `key` from `g:bufferline`, or return a `default` if none was present.
@@ -19,10 +18,6 @@ local function get(key, default)
     return value
   end
 end
-
-
---- @class bufferline.options.highlight
-local DEFAULT_HIGHLIGHTS = {alternate = false, visible = true}
 
 --- @class bufferline.options.diagnostics.severity
 --- @field enabled boolean
@@ -96,9 +91,14 @@ function options.hide()
   return get('hide', {})
 end
 
---- @return bufferline.options.highlight # `true` in a field enables distinguishing buffers of a particular kind
-function options.highlight()
-  return tbl_extend('keep', get('categories', {}), DEFAULT_HIGHLIGHTS)
+--- @return boolean
+function options.highlight_alternate()
+  return get('highlight_alternate', false)
+end
+
+--- @return boolean
+function options.highlight_visible()
+  return get('highlight_visible', true)
 end
 
 --- @return string icon

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -72,7 +72,7 @@ local state = require'bufferline.state'
 local utils = require'bufferline.utils'
 
 --- The highlight to use based on the state of a buffer.
-local HL_BY_ACTIVITY = {'Inactive', 'Visible', 'Current'}
+local HL_BY_ACTIVITY = {'Inactive', 'Visible', 'Alternate', 'Current'}
 
 --- Last value for tabline
 --- @type nil|string
@@ -768,8 +768,7 @@ local function generate_tabline(bufnrs, refocus)
 
     local activity = Buffer.get_activity(bufnr)
     local is_inactive = activity == 1
-    -- local is_visible = activity == 2
-    local is_current = activity == 3
+    local is_current = activity == 4
     local is_modified = buf_get_option(bufnr, 'modified')
     -- local is_closing = buffer_data.closing
     local is_pinned = state.is_pinned(bufnr)
@@ -820,7 +819,7 @@ local function generate_tabline(bufnrs, refocus)
       if has_icons then
         local iconChar, iconHl = icons.get_icon(bufnr, status)
         local hlName = is_inactive and 'BufferInactive' or iconHl
-        iconPrefix = has_icon_custom_colors and hl_tabline('Buffer' .. status .. 'Icon') or hlName and hl_tabline(hlName) or namePrefix
+        iconPrefix = has_icon_custom_colors and hl_tabline('Buffer' .. status .. 'Icon') or (hlName and hl_tabline(hlName) or namePrefix)
         icon = iconChar .. ' '
       end
     end
@@ -852,7 +851,6 @@ local function generate_tabline(bufnrs, refocus)
     local padding = (' '):rep(layout.padding_width)
 
     local item = {
-      is_current = is_current,
       width = buffer_data.width
         -- <padding> <base_widths[i]> <padding>
         or layout.base_widths[i] + (2 * layout.padding_width),


### PR DESCRIPTION
Adds `BufferAlternate`* series of highlight groups to categorize the previously-active buffer (i.e. the one which will be switched to when pressing `<C-^>`).

![A screenshot showing the feature](https://user-images.githubusercontent.com/36409591/203215588-da0deaec-d26d-42ae-91c1-75da20570013.png "'a' is alternate, 'b' is current, and 'c' is inactive")

```lua
require'bufferline'.setup {
  -- enable the distinction of alternate buffers
  categories = {alternate = true},

  -- hide alternate buffers
  hide = {alternate = true},
}
```

The diff will look better after we merge #334.

Closes #140