### PR TITLE
fix(buffer): no_name_title option

### DIFF
--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -91,19 +91,19 @@ return {
   --- @param hide_extensions boolean? if `true`, exclude the extension of the file
   --- @return string name
   get_name = function(bufnr, hide_extensions)
-    --- @type nil|string
-    local name = buf_is_valid(bufnr) and buf_get_name(bufnr) or nil
+    --- @type string
+    local name = buf_is_valid(bufnr) and buf_get_name(bufnr) or ''
 
     local no_name_title = options.no_name_title()
     local maximum_length = options.maximum_length()
 
-    if name then
+    if name ~= '' then
       name = buf_get_option(bufnr, 'buftype') == 'terminal' and terminalname(name) or utils.basename(name, hide_extensions)
     elseif no_name_title ~= nil and no_name_title ~= vim.NIL then
       name = no_name_title
     end
 
-    if name == '' or not name then
+    if name == '' then
       name = '[buffer ' .. bufnr .. ']'
     end
 


### PR DESCRIPTION
Apparently, the option `no_name_title` is not quite working. When I set it, even on new buffers it is not used.

In the `lua/bufferline/buffer.lua` file, apparently the "name" variable is getting there as empty string, and then the default `[buffer X]` is being used, so I added a little check in the if statement.

Without the change:

![image](https://user-images.githubusercontent.com/60318892/206214179-976447b3-dcf0-49fc-9a8b-272b3f30798c.png)

With the change:

![image](https://user-images.githubusercontent.com/60318892/206214226-715793ac-b6f0-4ecf-90d3-d1b2190e9ca4.png)

This is the barbar config I used:

![image](https://user-images.githubusercontent.com/60318892/206214444-65fc5c56-367c-4dfa-84b8-397766ebdc59.png)

Since I already came up with a possible solution, I decided to fork and open a PR instead of opening an issue. Sorry if this was not the preferred way. Should I open an issue anyways? Also, I think this solution does not impact other functionalities, but we never know.

And thanks for this plugin and your work for the community! You are awesome (: