### PR TITLE
feat: `BufferPickDelete` command

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -81,11 +81,13 @@ function bufferline.setup(user_config)
 
   create_user_command(
     'BufferMoveStart',
-    function(tbl) api.move_current_buffer_to(1) end,
+    function() api.move_current_buffer_to(1) end,
     {desc = 'Move current buffer to the front'}
   )
 
   create_user_command('BufferPick', api.pick_buffer, {desc = 'Pick a buffer'})
+
+  create_user_command('BufferPickDelete', api.pick_buffer_delete, {desc = 'Pick buffers to delete'})
 
   create_user_command('BufferPin', function() api.toggle_pin() end, {desc = 'Un/pin a buffer'})
 

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -44,6 +44,26 @@ local utils = require'bufferline.utils'
 --- @type bufferline.buffer
 local Buffer = require'bufferline.buffer'
 
+local ESC = vim.api.nvim_replace_termcodes('<Esc>', true, false, true)
+
+--- Initialize the buffer pick mode.
+--- @param fn fun()
+local function pick_buffer_wrap(fn)
+  if JumpMode.reinitialize then
+    JumpMode.initialize_indexes()
+  end
+
+  state.is_picking_buffer = true
+  render.update()
+  command('redrawtabline')
+
+  fn()
+
+  state.is_picking_buffer = false
+  render.update()
+  command('redrawtabline')
+end
+
 --- Shows an error that `bufnr` was not among the `state.buffers`
 --- @param bufnr integer
 local function notify_buffer_not_found(bufnr)
@@ -365,34 +385,49 @@ end
 
 --- Activate the buffer pick mode.
 function api.pick_buffer()
-  if JumpMode.reinitialize then
-    JumpMode.initialize_indexes()
-  end
+  pick_buffer_wrap(function()
+    local ok, byte = pcall(getchar)
+    if ok then
+      local letter = char(byte)
 
-  state.is_picking_buffer = true
-
-  render.update()
-  command('redrawtabline')
-
-  state.is_picking_buffer = false
-
-  local ok, byte = pcall(getchar)
-  if ok then
-    local letter = char(byte)
-
-    if letter ~= '' then
-      if JumpMode.buffer_by_letter[letter] ~= nil then
-        set_current_buf(JumpMode.buffer_by_letter[letter])
-      else
-        notify("Couldn't find buffer", vim.log.levels.WARN, {title = 'barbar.nvim'})
+      if letter ~= '' then
+        if JumpMode.buffer_by_letter[letter] ~= nil then
+          set_current_buf(JumpMode.buffer_by_letter[letter])
+        else
+          notify("Couldn't find buffer", vim.log.levels.WARN, {title = 'barbar.nvim'})
+        end
       end
+    else
+      notify("Invalid input", vim.log.levels.WARN, {title = 'barbar.nvim'})
     end
-  else
-    notify("Invalid input", vim.log.levels.WARN, {title = 'barbar.nvim'})
-  end
+  end)
+end
 
-  render.update()
-  command('redrawtabline')
+--- Activate the buffer pick delete mode.
+function api.pick_buffer_delete()
+  pick_buffer_wrap(function()
+    while true do
+      local ok, byte = pcall(getchar)
+      if ok then
+        local letter = char(byte)
+
+        if letter ~= '' then
+          if JumpMode.buffer_by_letter[letter] ~= nil then
+            bbye.bdelete(false, JumpMode.buffer_by_letter[letter])
+          elseif letter == ESC then
+            break
+          else
+            notify("Couldn't find buffer", vim.log.levels.WARN, {title = 'barbar.nvim'})
+          end
+        end
+      else
+        notify("Invalid input", vim.log.levels.WARN, {title = 'barbar.nvim'})
+      end
+
+      render.update()
+      command('redrawtabline')
+    end
+  end)
 end
 
 --- Offset the rendering of the bufferline


### PR DESCRIPTION
This PR adds the `:BufferPickDelete` command, which allows the user to iteratively select buffers which should be deleted (until pressing `<Esc>`).

Closes #73.

To do:

* [ ] Documentation