### PR TITLE
perf: c8f972dbab8d90d340cf6e840b73cddc12c350b2

### DIFF
--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -91,8 +91,7 @@ end
 --- Close all open buffers, except those in visible windows.
 function api.close_all_but_visible()
   for _, bufnr in ipairs(state.buffers) do
-    local activity = Buffer.get_activity(bufnr)
-    if not (activity == 2 or activity == 4) then
+    if Buffer.get_activity(bufnr) < 3 then
       bbye.bdelete(false, bufnr)
     end
   end

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -45,14 +45,14 @@ local function terminalname(name)
 end
 
 --- @param buffer_number integer
---- @return bufferline.buffer.activity # whether `bufnr` is inactive, visible, the alternate file, or currently selected (in that order).
+--- @return bufferline.buffer.activity # whether `bufnr` is inactive, the alternate file, visible, or currently selected (in that order).
 local function get_activity(buffer_number)
   if get_current_buf() == buffer_number then
     return 4
   elseif options.highlight_alternate() and bufnr('#') == buffer_number then
-    return 3
-  elseif options.highlight_visible() and bufwinnr(buffer_number) ~= -1 then
     return 2
+  elseif options.highlight_visible() and bufwinnr(buffer_number) ~= -1 then
+    return 3
   end
 
   return 1

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -72,7 +72,7 @@ local state = require'bufferline.state'
 local utils = require'bufferline.utils'
 
 --- The highlight to use based on the state of a buffer.
-local HL_BY_ACTIVITY = {'Inactive', 'Visible', 'Alternate', 'Current'}
+local HL_BY_ACTIVITY = {'Inactive', 'Alternate', 'Visible', 'Current'}
 
 --- Last value for tabline
 --- @type nil|string


### PR DESCRIPTION
Allows use of a `<` check for `api.close_all_but_visible` by making alternate buffers `status == 2` rather than `status == 3`