### PR TITLE
feat: `highlight_inactive_file_icons` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ let bufferline.hide = {'extensions': v:true, 'inactive': v:true}
 " Disable highlighting alternate buffers
 let bufferline.highlight_alternate = v:false
 
+" Disable highlighting file icons in inactive buffers
+let bufferline.highlight_inactive_file_icons = v:false
+
 " Enable highlighting visible buffers
 let bufferline.highlight_visible = v:true
 
@@ -350,6 +353,9 @@ require'bufferline'.setup {
 
   -- Disable highlighting alternate buffers
   highlight_alternate = false,
+
+  -- Disable highlighting file icons in inactive buffers
+  highlight_inactive_file_icons = false,
 
   -- Enable highlighting visible buffers
   highlight_visible = true,

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -365,6 +365,14 @@ Controls if icons are rendered on each tab.
     let g:bufferline.highlight_visible = v:true
 <
 
+                                  *g:bufferline.highlight_inactive_file_icons*
+`g:bufferline.highlight_inactive_file_icons`  boolean  (default |v:false|)
+
+  Enables highlighting the file icons of inactive buffers.
+>
+    let g:bufferline.highlight_inactive_file_icons = v:true
+<
+
 ==============================================================================
 5. Integrations                                          *barbar-integrations*
 

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -30,6 +30,8 @@ local utils = require'bufferline.utils'
 
 --- @alias bufferline.buffer.activity 1|2|3|4
 
+--- @alias bufferline.buffer.activity.name 'Inactive'|'Alternate'|'Visible'|'Current'
+
 --- The character used to delimit paths (e.g. `/` or `\`).
 local separator = package.config:sub(1,1)
 

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -16,11 +16,22 @@ local hl = require'bufferline.utils'.hl
 local status, web = pcall(require, 'nvim-web-devicons')
 
 --- @class bufferline.icons.group
---- @field buffer_status "Current"|"Inactive"|"Visible" the state of the buffer whose icon is being highlighted
+--- @field buffer_status bufferline.buffer.activity.name the state of the buffer whose icon is being highlighted
 --- @field icon_hl string the group to highlight an icon with
 
 --- @type bufferline.icons.group[]
 local hl_groups = {}
+
+--- Sets the highlight group used for a type of buffer's file icon
+--- @param buffer_status bufferline.buffer.activity.name
+--- @param icon_hl string
+local function hl_buffer_icon(buffer_status, icon_hl)
+  hl.set(
+    icon_hl .. buffer_status,
+    hl.bg_or_default({'Buffer' .. buffer_status}, 'none'),
+    hl.fg_or_default({icon_hl}, 'none')
+  )
+end
 
 --- @class bufferline.icons
 return {
@@ -29,16 +40,12 @@ return {
   -- already highlighted.
   set_highlights = function()
     for _, group in ipairs(hl_groups) do
-      hl.set(
-        group.icon_hl .. group.buffer_status,
-        hl.bg_or_default({'Buffer' .. group.buffer_status}, 'none'),
-        hl.fg_or_default({group.icon_hl}, 'none')
-      )
+      hl_buffer_icon(group.buffer_status, group.icon_hl)
     end
  end,
 
   --- @param bufnr integer
-  --- @param buffer_status "Current"|"Inactive"|"Visible"
+  --- @param buffer_status bufferline.buffer.activity.name
   --- @return string icon, string highlight_group
   get_icon = function(bufnr, buffer_status)
     if status == false then
@@ -79,11 +86,7 @@ return {
     end
 
     if icon_hl and hlexists(icon_hl .. buffer_status) < 1 then
-      hl.set(
-        icon_hl .. buffer_status,
-        hl.bg_or_default({'Buffer' .. buffer_status}, 'none'),
-        hl.fg_or_default({icon_hl}, 'none')
-      )
+      hl_buffer_icon(buffer_status, icon_hl)
       hl_groups[#hl_groups + 1] = { buffer_status = buffer_status, icon_hl = icon_hl }
     end
 

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -99,6 +99,11 @@ function options.highlight_alternate()
 end
 
 --- @return boolean
+function options.highlight_inactive_file_icons()
+  return get('highlight_inactive_file_icons', false)
+end
+
+--- @return boolean
 function options.highlight_visible()
   return get('highlight_visible', true)
 end

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -828,7 +828,7 @@ local function generate_tabline(bufnrs, refocus)
 
       if has_file_icons then
         local iconChar, iconHl = icons.get_icon(bufnr, status)
-        local hlName = is_inactive and 'BufferInactive' or iconHl
+        local hlName = is_inactive and not options.highlight_inactive_file_icons() and 'BufferInactive' or iconHl
         iconPrefix = has_icon_custom_colors and hl_tabline('Buffer' .. status .. 'Icon') or (hlName and hl_tabline(hlName) or namePrefix)
         icon = iconChar .. ' '
       end


### PR DESCRIPTION
Closes #346.

```lua
require'bufferline'.setup {highlight_inactive_file_icons = true}
```

Before:

![cap](https://user-images.githubusercontent.com/36409591/209998838-c37a3233-3fdf-4443-a439-3faa89de2431.png)

After:

![cap](https://user-images.githubusercontent.com/36409591/209999090-c99727da-2ed0-43bb-ac3d-9d03f08ed4b6.png)