### PR TITLE
docs(README): installation instructions for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Plug 'nvim-tree/nvim-web-devicons'
 Plug 'romgrk/barbar.nvim'
 ```
 
+#### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+```lua
+require('lazy').setup {
+  {'romgrk/barbar.nvim', dependencies = 'nvim-tree/nvim-web-devicons'},
+}
+```
+
 #### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use 'nvim-tree/nvim-web-devicons'


### PR DESCRIPTION
The author of `packer.nvim` [uses `lazy.nvim`](https://github.com/wbthomason/dotfiles/blob/main/dot_config/nvim/init.lua#L5) now, so I figured we should provide instructions for that plugin too. 