### PR TITLE
docs(README): make filetree integration more universal

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,18 +505,16 @@ Add this autocmds to your configuration.
 
 ```lua
 vim.api.nvim_create_autocmd('BufWinEnter', {
-  pattern = '*',
-  callback = function()
-    if vim.bo.filetype == 'NvimTree' then
+  callback = function(tbl)
+    if vim.bo[tbl.buf].filetype == 'NvimTree' then
       require'bufferline.api'.set_offset(31, 'FileTree')
     end
   end
 })
 
-vim.api.nvim_create_autocmd('BufWinLeave', {
-  pattern = '*',
-  callback = function()
-    if vim.fn.expand('<afile>'):match('NvimTree') then
+vim.api.nvim_create_autocmd({'BufWinLeave', 'BufWipeout'}, {
+  callback = function(tbl)
+    if vim.bo[tbl.buf].filetype == 'NvimTree' then
       require'bufferline.api'.set_offset(0)
     end
   end


### PR DESCRIPTION
Closes #355.

Other filetrees don't always name the buffer after the file tree, but most use the filetype.