### PR TITLE
Fix session load

### DIFF
--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -481,9 +481,19 @@ function render.enable()
 
   create_autocmd('SessionLoadPost', {
     callback = function()
+      if state.loading_session then
+        return
+      end
+
+      state.loading_session = true
+
       if vim.g.Bufferline__session_restore then
         command(vim.g.Bufferline__session_restore)
       end
+
+      vim.fn.timer_start(100, function()
+        state.loading_session = false
+      end)
 
       schedule(function() render.update(true) end)
     end,

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -40,6 +40,7 @@ local utils = require'bufferline.utils'
 --- @field pins {[integer]: boolean} whether a buffer is pinned
 local state = {
   is_picking_buffer = false,
+  loading_session = false,
   buffers = {},
   data_by_bufnr = {},
 

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -35,6 +35,7 @@ local utils = require'bufferline.utils'
 
 --- @class bufferline.state
 --- @field is_picking_buffer boolean whether the user is currently in jump-mode
+--- @field loading_session boolean `true` if a `SessionLoadPost` event is being processed
 --- @field buffers integer[] the open buffers, in visual order.
 --- @field data_by_bufnr {[integer]: bufferline.state.data} the buffer data indexed on buffer number
 --- @field pins {[integer]: boolean} whether a buffer is pinned


### PR DESCRIPTION
Fixes: https://github.com/romgrk/barbar.nvim/issues/364

About the issue:

The SessionLoadPre is called multiple times for some reason.  If i quickly load a session (when vim start), the first call will unset the pinned (because state.buffers is already set probably).  With this, is prevented to call multiple times so quickly.

This PR Fixes LSP-Zero with session plugins that auto-load session on neovim start.

This is not the best solution but it's work! 

cc @Iron-E 