### PR TITLE
ref: add fallback to `:BufferNext`/`Previous`

### DIFF
--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -415,11 +415,11 @@ function api.pick_buffer()
         if JumpMode.buffer_by_letter[letter] ~= nil then
           set_current_buf(JumpMode.buffer_by_letter[letter])
         else
-          notify("Couldn't find buffer", vim.log.levels.WARN, {title = 'barbar.nvim'})
+          notify("Couldn't find buffer", vim.log.levels.ERROR, {title = 'barbar.nvim'})
         end
       end
     else
-      notify("Invalid input", vim.log.levels.WARN, {title = 'barbar.nvim'})
+      notify("Invalid input", vim.log.levels.ERROR, {title = 'barbar.nvim'})
     end
   end)
 end
@@ -439,11 +439,11 @@ function api.pick_buffer_delete()
           elseif letter == ESC then
             break
           else
-            notify("Couldn't find buffer", vim.log.levels.WARN, {title = 'barbar.nvim'})
+            notify("Couldn't find buffer", vim.log.levels.ERROR, {title = 'barbar.nvim'})
           end
         end
       else
-        notify("Invalid input", vim.log.levels.WARN, {title = 'barbar.nvim'})
+        notify("Invalid input", vim.log.levels.ERROR, {title = 'barbar.nvim'})
       end
 
       render.update()

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -75,21 +75,19 @@ end
 --- Get the list of buffers
 --- @return integer[] bufnrs
 function state.get_buffer_list()
-  local buffers = list_bufs()
   local result = {}
 
   local exclude_ft = options.exclude_ft()
   local exclude_name = options.exclude_name()
   local hide_extensions = options.hide().extensions
 
-  for _, buffer in ipairs(buffers) do
-    if buf_get_option(buffer, 'buflisted') then
-      local ft = buf_get_option(buffer, 'filetype')
-      if not utils.has(exclude_ft, ft) then
-        local name = utils.basename(buf_get_name(buffer), hide_extensions)
-        if not utils.has(exclude_name, name) then
-          result[#result + 1] = buffer
-        end
+  for _, bufnr in ipairs(list_bufs()) do
+    if buf_get_option(bufnr, 'buflisted') and
+      not utils.has(exclude_ft, buf_get_option(bufnr, 'filetype'))
+    then
+      local name = buf_get_name(bufnr)
+      if not utils.has(exclude_name, utils.basename(name, hide_extensions)) then
+        table.insert(result, bufnr)
       end
     end
   end


### PR DESCRIPTION
Closes #367.

This PR adds a fallback for when a buffer is not found in the `state.buffers` list, and the `:BufferNext`/`Previous` command is run:

1. The alternate buffer, if it is in `state.buffers` (as `state.buffers` only lists valid, non-excluded buffers); or
2. `state.buffers[1]`

Fallback incidents are logged using `vim.notify` at log level `INFO`. It is possible to override the `vim.notify` function to filter messages below a certain log level.

