### PR TITLE
ref: integrate with nvim-notify using `utils.notify`

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -2,7 +2,6 @@ local bufnr = vim.fn.bufnr --- @type function
 local command = vim.api.nvim_command --- @type function
 local create_user_command = vim.api.nvim_create_user_command --- @type function
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
-local notify = vim.notify
 
 local api = require'bufferline.api' --- @type bufferline.api
 local bbye = require'bufferline.bbye' --- @type bbye
@@ -47,8 +46,7 @@ function bufferline.setup(user_config)
     function(tbl)
       local index = tonumber(tbl.args)
       if not index then
-        notify('Invalid argument to `:BufferGoto`', vim.log.levels.ERROR, {title = 'barbar.nvim'})
-        return
+        return utils.notify('Invalid argument to `:BufferGoto`', vim.log.levels.ERROR)
       end
       api.goto_buffer(index)
     end,

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -12,7 +12,6 @@ local bufwinnr = vim.fn.bufwinnr --- @type function
 local command = vim.api.nvim_command --- @type function
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local getchar = vim.fn.getchar --- @type function
-local notify = vim.notify
 local set_current_buf = vim.api.nvim_set_current_buf --- @type function
 
 -- TODO: remove `vim.fs and` after 0.8 release
@@ -53,10 +52,9 @@ end
 --- @param buffer_number integer
 --- @return nil
 local function notify_buffer_not_found(buffer_number)
-  notify(
+  utils.notify(
     'Current buffer (' .. buffer_number .. ") not found in bufferline.nvim's list of buffers: " .. vim.inspect(state.buffers),
-    vim.log.levels.ERROR,
-    {title = 'barbar.nvim'}
+    vim.log.levels.ERROR
   )
 end
 
@@ -179,10 +177,9 @@ function api.goto_buffer(index)
   if buffer_number then
     set_current_buf(buffer_number)
   else
-    notify(
+    utils.notify(
       'E86: buffer at index ' .. index .. ' in list ' .. vim.inspect(state.buffers) .. ' does not exist.',
-      vim.log.levels.ERROR,
-      {title = 'barbar.nvim'}
+      vim.log.levels.ERROR
     )
   end
 end
@@ -195,8 +192,7 @@ function api.goto_buffer_relative(steps)
   render.get_updated_buffers()
 
   if #state.buffers < 1 then
-    notify('E85: There is no listed buffer', vim.log.levels.ERROR, {title = 'barbar.nvim'})
-    return
+    return utils.notify('E85: There is no listed buffer', vim.log.levels.ERROR)
   end
 
   local current_bufnr = render.set_current_win_listed_buffer()
@@ -204,11 +200,10 @@ function api.goto_buffer_relative(steps)
 
   if not idx then -- fall back to: 1. the alternate buffer, 2. the first buffer
     idx = utils.index_of(state.buffers, bufnr'#') or 1
-    notify(
+    utils.notify(
       "Couldn't find buffer #" .. current_bufnr .. ' in the list: ' .. vim.inspect(state.buffers) ..
         '. Falling back to buffer #' .. state.buffers[idx],
-      vim.log.levels.INFO,
-      {title = 'barbar.nvim'}
+      vim.log.levels.INFO
     )
   end
 
@@ -322,8 +317,7 @@ function api.move_current_buffer_to(idx)
   local from_idx = utils.index_of(state.buffers, current_bufnr)
 
   if from_idx == nil then
-    notify_buffer_not_found(current_bufnr)
-    return
+    return notify_buffer_not_found(current_bufnr)
   end
 
   move_buffer(from_idx, idx)
@@ -339,8 +333,7 @@ function api.move_current_buffer(steps)
   local idx = utils.index_of(state.buffers, current_bufnr)
 
   if idx == nil then
-    notify_buffer_not_found(current_bufnr)
-    return
+    return notify_buffer_not_found(current_bufnr)
   end
 
   move_buffer(idx, idx + steps)
@@ -416,11 +409,11 @@ function api.pick_buffer()
         if JumpMode.buffer_by_letter[letter] ~= nil then
           set_current_buf(JumpMode.buffer_by_letter[letter])
         else
-          notify("Couldn't find buffer", vim.log.levels.ERROR, {title = 'barbar.nvim'})
+          utils.notify("Couldn't find buffer", vim.log.levels.ERROR)
         end
       end
     else
-      notify("Invalid input", vim.log.levels.ERROR, {title = 'barbar.nvim'})
+      utils.notify('Invalid input', vim.log.levels.ERROR)
     end
   end)
 end
@@ -440,11 +433,11 @@ function api.pick_buffer_delete()
           elseif letter == ESC then
             break
           else
-            notify("Couldn't find buffer", vim.log.levels.ERROR, {title = 'barbar.nvim'})
+            utils.notify("Couldn't find buffer", vim.log.levels.ERROR)
           end
         end
       else
-        notify("Invalid input", vim.log.levels.ERROR, {title = 'barbar.nvim'})
+        utils.notify('Invalid input', vim.log.levels.ERROR)
       end
 
       render.update()

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -7,12 +7,12 @@ local buf_get_option = vim.api.nvim_buf_get_option --- @type function
 local command = vim.api.nvim_command --- @type function
 local fnamemodify = vim.fn.fnamemodify --- @type function
 local hlexists = vim.fn.hlexists --- @type function
-local notify = vim.notify
 
-local hl = require'bufferline.utils'.hl --- @type bufferline.utils.hl
+local utils = require'bufferline.utils' --- @type bufferline.utils
+local hl = utils.hl
 
 --- @type boolean, {get_icon: fun(name: string, ext?: string, opts?: {default: nil|boolean}): string, string}
-local status, web = pcall(require, 'nvim-web-devicons')
+local ok, web = pcall(require, 'nvim-web-devicons')
 
 --- @class bufferline.icons.group
 --- @field buffer_status bufferline.buffer.activity.name the state of the buffer whose icon is being highlighted
@@ -47,13 +47,12 @@ return {
   --- @param buffer_status bufferline.buffer.activity.name
   --- @return string icon, string highlight_group
   get_icon = function(bufnr, buffer_status)
-    if status == false then
-      notify(
+    if ok == false then
+      utils.notify(
         'barbar: bufferline.icons is set to v:true but "nvim-dev-icons" was not found.' ..
           '\nbarbar: icons have been disabled. Set `bufferline.icons` to `false` or ' ..
           'install "nvim-dev-icons" to disable this message.',
-        vim.log.levels.WARN,
-        {title = 'barbar.nvim'}
+        vim.log.levels.WARN
       )
 
       if type(vim.g.bufferline) == 'table' then

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -22,7 +22,6 @@ local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local has = vim.fn.has --- @type function
 local list_tabpages = vim.api.nvim_list_tabpages --- @type function
 local list_wins = vim.api.nvim_list_wins --- @type function
-local notify = vim.notify
 local schedule = vim.schedule --- @type function
 local set_current_buf = vim.api.nvim_set_current_buf --- @type function
 local set_current_win = vim.api.nvim_set_current_win --- @type function
@@ -977,12 +976,11 @@ function render.update(update_names, refocus)
 
   if not ok then
     render.disable()
-    notify(
+    utils.notify(
       "Barbar detected an error while running. Barbar disabled itself :/ " ..
         "Include this in your report: " ..
         tostring(result),
-      vim.log.levels.ERROR,
-      {title = 'barbar.nvim'}
+      vim.log.levels.ERROR
     )
 
     return

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -4,9 +4,10 @@
 
 local fnamemodify = vim.fn.fnamemodify --- @type function
 local get_hl_by_name = vim.api.nvim_get_hl_by_name --- @type function
-local list_slice = vim.list_slice
-local set_hl = vim.api.nvim_set_hl --- @type function
 local hlexists = vim.fn.hlexists --- @type function
+local list_slice = vim.list_slice
+local notify = vim.notify
+local set_hl = vim.api.nvim_set_hl --- @type function
 
 --- Generate a color.
 --- @param groups string[] the groups to source the color from.
@@ -144,6 +145,14 @@ return {
   --- @return T[] sliced
   list_slice_from_end = function(list, index_from_end)
     return list_slice(list, #list - index_from_end + 1)
+  end,
+
+  --- Use `vim.notify` with a `msg` and log `level`. Integrates with `nvim-notify`.
+  --- @param msg string
+  --- @param level 0|1|2|3|4|5
+  --- @return nil
+  notify = function(msg, level)
+    notify(msg, level, {title = 'barbar.nvim'})
   end,
 
   relative = relative,


### PR DESCRIPTION
We've been passing around `{title = 'barbar.nvim'}` (to integrate with nvim-notify) in every single_`vim.notify` call. This commit extracts that into `utils.notify`, which will also make it easier should we add any other options that integrate with that plugin.

The diff will improve after merging #369