### PR TITLE
feat(bufferline): customize buffer close behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ let bufferline.diagnostics = [
 let bufferline.exclude_ft = ['javascript']
 let bufferline.exclude_name = ['package.json']
 
+" A buffer to this direction will be focused (if it exists) when closing the current buffer.
+" Valid options are 'left' (the default) and 'right'
+let bufferline.focus_on_close = 'left'
+
 " Hide inactive buffers and file extensions. Other options are `alternate`, `current`, and `visible`.
 let bufferline.hide = {'extensions': v:true, 'inactive': v:true}
 
@@ -353,6 +357,10 @@ require'bufferline'.setup {
   -- Excludes buffers from the tabline
   exclude_ft = {'javascript'},
   exclude_name = {'package.json'},
+
+  -- A buffer to this direction will be focused (if it exists) when closing the current buffer.
+  -- Valid options are 'left' (the default) and 'right'
+  focus_on_close = 'left',
 
   -- Hide inactive buffers and file extensions. Other options are `alternate`, `current`, and `visible`.
   hide = {extensions = true, inactive = true},

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -373,6 +373,15 @@ Controls if icons are rendered on each tab.
     let g:bufferline.highlight_inactive_file_icons = v:true
 <
 
+                                                 *g:bufferline.focus_on_close*
+`g:bufferline.focus_on_close`  "left"|"right"  (default "left")
+
+  A buffer to this direction will be focused (if it exists) when closing the
+  current buffer.
+>
+    let g:bufferline.focus_on_close = "left"
+<
+
 ==============================================================================
 5. Integrations                                          *barbar-integrations*
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -128,26 +128,16 @@ function bufferline.setup(user_config)
     {desc = 'Order the bufferline by window number'}
   )
 
-  create_user_command(
-    'BufferClose',
-    function(tbl)
-      local focus_buffer = state.find_next_buffer(get_current_buf())
-      bbye.bdelete(tbl.bang, tbl.args, tbl.smods or tbl.mods, focus_buffer)
-    end,
-    {bang = true, complete = 'buffer', desc = 'Close the current buffer.', nargs = '?'}
-  )
-
-  create_user_command(
-    'BufferDelete',
-    function(tbl) bbye.bdelete(tbl.bang, tbl.args, tbl.smods or tbl.mods) end,
-    {bang = true, complete = 'buffer', desc = 'Synonym for `:BufferClose`', nargs = '?'}
-  )
-
-  create_user_command(
-    'BufferWipeout',
-    function(tbl) bbye.bwipeout(tbl.bang, tbl.args, tbl.smods or tbl.mods) end,
-    {bang = true, complete = 'buffer', desc = 'Wipe out the buffer', nargs = '?'}
-  )
+  for cmd, desc in pairs {
+    Close = 'Close the current buffer',
+    Delete = 'Synonym for `:BufferClose`',
+  } do
+    create_user_command(
+      'Buffer' .. cmd,
+      function(tbl) bbye.bdelete(tbl.bang, tbl.args, tbl.smods or tbl.mods) end,
+      {bang = true, complete = 'buffer', desc = desc, nargs = '?'}
+    )
+  end
 
   create_user_command(
     'BufferCloseAllButCurrent',

--- a/lua/bufferline/bbye.lua
+++ b/lua/bufferline/bbye.lua
@@ -31,6 +31,7 @@ local create_autocmd = vim.api.nvim_create_autocmd --- @type function
 local exec_autocmds = vim.api.nvim_exec_autocmds --- @type function
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local get_current_win = vim.api.nvim_get_current_win --- @type function
+local list_bufs = vim.api.nvim_list_bufs --- @type function
 local list_wins = vim.api.nvim_list_wins --- @type function
 local notify = vim.notify
 local set_current_buf = vim.api.nvim_set_current_buf --- @type function
@@ -40,6 +41,7 @@ local win_is_valid = vim.api.nvim_win_is_valid --- @type function
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
 local buf_set_option = vim.api.nvim_buf_set_option --- @type function
 
+local options = require'bufferline.options'
 local state = require'bufferline.state'
 local utils = require'bufferline.utils'
 
@@ -62,6 +64,46 @@ local cmd = vim.api.nvim_cmd and
   function(action, buffer_number, force, mods)
     command((mods or '') .. " " .. action .. (force and '!' or '') .. " " .. buffer_number)
   end
+
+--- @param buffer_number integer
+--- @return nil|integer bufnr of the buffer to focus
+local function get_focus_on_close(buffer_number)
+  local state_bufnrs = state.buffers
+  local focus_on_close = options.focus_on_close()
+
+  if #state_bufnrs < 1 -- all of the buffers are excluded or unlisted
+    or (#state_bufnrs == 1 and state_bufnrs[1] == buffer_number) -- only one buffer is open, and that buffer is the current one
+  then
+    local buffers = list_bufs()
+    if focus_on_close == 'right' then
+      buffers = utils.reverse(buffers)
+    end
+
+    for _, nr in ipairs(buffers) do
+      if buf_get_option(nr, 'buflisted') then
+        return nr -- there was a listed buffer open, focus it.
+      end
+    end
+
+    -- there are no listed, focusable buffers open
+    return nil
+  end
+
+  local add, fallback --- @type integer, integer
+  if focus_on_close == 'left' then
+    add, fallback = -1, 1
+  else -- focus_on_close == 'right'
+    add, fallback = 1, #state_bufnrs
+  end
+
+  local to_focus --- @type nil|integer
+  local index = utils.index_of(state_bufnrs, buffer_number)
+  if index then
+    to_focus = state_bufnrs[index + add]
+  end
+
+  return to_focus or state_bufnrs[fallback]
+end
 
 --- Use `vim.notify` to print an error `msg`
 --- @param msg string
@@ -109,9 +151,8 @@ local bbye = {}
 --- @param force boolean if true, forcefully delete the buffer
 --- @param buffer? integer|string the name of the buffer.
 --- @param mods? string|{[string]: any} the modifiers to the command (e.g. `'verbose'`)
---- @param focus_id? number the preferred buffer to focus
 --- @return nil
-function bbye.delete(action, force, buffer, mods, focus_id)
+function bbye.delete(action, force, buffer, mods)
   local buffer_number = type(buffer) == 'string' and bufnr(buffer) or tonumber(buffer) or get_current_buf()
 
   if buffer_number < 0 then
@@ -143,26 +184,22 @@ function bbye.delete(action, force, buffer, mods, focus_id)
 
   -- For cases where adding buffers causes new windows to appear or hiding some
   -- causes windows to disappear and thereby decrement, loop backwards.
-  local window_ids = list_wins()
-  local window_ids_reversed = utils.reverse(window_ids)
-
-  for _, window_number in ipairs(window_ids_reversed) do
+  for _, window_number in ipairs(utils.reverse(list_wins())) do
     if win_get_buf(window_number) == buffer_number then
       set_current_win(window_number)
 
       -- Bprevious also wraps around the buffer list, if necessary:
-      local no_errors = pcall(function()
-        local previous_buffer = focus_id and focus_id or bufnr('#')
-        if previous_buffer > 0 and buflisted(previous_buffer) == 1 then
-          set_current_buf(previous_buffer)
+      local ok = pcall(function()
+        local focus_buffer = get_focus_on_close(buffer_number)
+        if focus_buffer then
+          set_current_buf(focus_buffer)
         else
           command 'bprevious'
         end
       end)
 
-      if not (no_errors or vim.v.errmsg:match('E85')) then
-        err(vim.v.errmsg)
-        return
+      if not (ok or vim.v.errmsg:match('E85')) then
+        return err(vim.v.errmsg)
       end
 
       -- If the buffer is still the same, we couldn't find a new buffer,
@@ -201,20 +238,18 @@ end
 --- @param force boolean if true, forcefully delete the buffer
 --- @param buffer? integer|string the name of the buffer.
 --- @param mods? string|{[string]: any} the modifiers to the command (e.g. `'verbose'`)
---- @param focus_id? number the preferred buffer to focus
 --- @return nil
-function bbye.bdelete(force, buffer, mods, focus_id)
-  bbye.delete('bdelete', force, buffer, mods, focus_id)
+function bbye.bdelete(force, buffer, mods)
+  bbye.delete('bdelete', force, buffer, mods)
 end
 
 --- 'bwipeout' a buffer
 --- @param force boolean if true, forcefully delete the buffer
 --- @param buffer? integer|string the name of the buffer.
 --- @param mods? string|{[string]: any} the modifiers to the command (e.g. `'verbose'`)
---- @param focus_id? number the preferred buffer to focus
 --- @return nil
-function bbye.bwipeout(force, buffer, mods, focus_id)
-  bbye.delete('bwipeout', force, buffer, mods, focus_id)
+function bbye.bwipeout(force, buffer, mods)
+  bbye.delete('bwipeout', force, buffer, mods)
 end
 
 return bbye

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -88,6 +88,11 @@ function options.file_icons(icon_option)
   return icon_option == true or icon_option == 'both' or icon_option == 'buffer_number_with_icon'
 end
 
+--- @return 'left'|'right' enabled
+function options.focus_on_close()
+  return get('focus_on_close', 'left')
+end
+
 --- @return bufferline.options.hide
 function options.hide()
   return get('hide', {})

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -150,26 +150,6 @@ end
 
 -- Read/write state
 
--- Return the bufnr of the buffer to the right of `buffer_number`
--- @param buffer_number int
--- @return int|nil
-function state.find_next_buffer(buffer_number)
-  local index = utils.index_of(state.buffers, buffer_number)
-  if index == nil then
-    return
-  end
-
-  if index + 1 > #state.buffers then
-    index = index - 1
-    if index <= 0 then
-      return nil
-    end
-  else
-    index = index + 1
-  end
-  return state.buffers[index]
-end
-
 --- Update the names of all buffers in the bufferline.
 --- @return nil
 function state.update_names()

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -172,8 +172,8 @@ local utils = {
   --- @return T[] reversed
   reverse = function(list)
     local reversed = {}
-    while #reversed < #list do
-      reversed[#reversed + 1] = list[#list - #reversed]
+    for i = #list, 1, -1 do
+      table.insert(reversed, list[i])
     end
     return reversed
   end,


### PR DESCRIPTION
Closes #368

## About

In a previous request (issue #234, PR #270), it was asked that barbar.nvim mimic the behavior of a browser when closing buffers: choose the buffer to the right of the current buffer.

* __Note:__ I tested FireFox to double check the behavior matched, and found that the current behavior does work as "intended" (i.e. it works like a web browser does).

Code has been added to ensure that the behavior of `:BufferClose` and `:BufferDelete` never differs in the future, since they are supposed to be true synonyms.

## Config

To access this feature, simply do:

```lua
require'bufferline'.setup {focus_on_close = 'left'} -- or 'right'
```

## Todo

* [x] Decide name for option, and values we should allow
* [ ] Document new option
* [x] Testing

---

cc: @sarmong