### PR TITLE
docs: Update readme with code that works for resizable filetrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,20 +504,23 @@ To ensure tabs begin with the shown buffer you can set an offset for the tabline
 Add this autocmds to your configuration.
 
 ```lua
-vim.api.nvim_create_autocmd('BufWinEnter', {
-  callback = function(tbl)
-    if vim.bo[tbl.buf].filetype == 'NvimTree' then
-      require'bufferline.api'.set_offset(31, 'FileTree')
+local filetreename = 'neo-tree'
+vim.api.nvim_create_autocmd({ 'BufWinEnter', 'WinScrolled' }, {
+    callback = function(tbl)
+        if vim.bo[tbl.buf].filetype == filetreename then
+            local window_id = vim.fn.bufwinid(tbl.buf)
+            local width = vim.fn.winwidth(window_id)
+            require 'bufferline.api'.set_offset(width, 'FileTree')
+        end
     end
-  end
 })
 
-vim.api.nvim_create_autocmd({'BufWinLeave', 'BufWipeout'}, {
-  callback = function(tbl)
-    if vim.bo[tbl.buf].filetype == 'NvimTree' then
-      require'bufferline.api'.set_offset(0)
+vim.api.nvim_create_autocmd({ 'BufWinLeave', 'BufWipeout' }, {
+    callback = function(tbl)
+        if vim.bo[tbl.buf].filetype == filetreename then
+            require 'bufferline.api'.set_offset(0)
+        end
     end
-  end
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ![demo](./static/demo.gif)
 
 <h1 align="center">
@@ -501,64 +500,37 @@ To ensure tabs begin with the shown buffer you can set an offset for the tabline
 
 ![filetree-with-offset](./static/filetree-with-offset.png)
 
-Add this autocmds to your configuration.
+Add this `autocmd` to your configuration:
 
 ```lua
-local filetreename = 'neo-tree'
-local function get_filetree_window()
-    for _, windowId in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
-        local buffer = vim.api.nvim_win_get_buf(windowId)
-        if vim.api.nvim_buf_get_option(buffer, 'ft') == filetreename then
-            return windowId
+vim.api.nvim_create_autocmd('FileType', {
+  callback = function(tbl)
+    local set_offset = require('bufferline.api').set_offset
+
+    local bufwinid
+    local last_width
+    local autocmd = vim.api.nvim_create_autocmd('WinScrolled', {
+      callback = function()
+        bufwinid = bufwinid or vim.fn.bufwinid(tbl.buf)
+        local width = vim.api.nvim_win_get_width(bufwinid)
+
+        if last_width ~= width then
+          set_offset(width, 'FileTree')
         end
-    end
-    return nil
-end
+      end,
+    })
 
-local function get_filetree_width()
-    local windowId = get_filetree_window()
-    if windowId == nil then return end
-    return vim.fn.winwidth(windowId)
-end
-
-vim.api.nvim_create_autocmd({ 'BufWinEnter', 'WinScrolled', 'BufWinLeave', 'BufWipeout' }, {
-    callback = function()
-        local width = get_filetree_width()
-        require('bufferline.api').set_offset(width or 0)
-    end
+    vim.api.nvim_create_autocmd('BufWipeout', {
+      buffer = tbl.buf,
+      callback = function()
+        vim.api.nvim_del_autocmd(autocmd)
+        set_offset(0)
+      end,
+      once = true,
+    })
+  end,
+  pattern = 'NvimTree', -- or any other filetree's `ft`
 })
-end
-
-```
-
-And add a mapping to use the above functions:
-
-```vim
-noremap <silent> <C-n> :lua require'tree'.toggle()<CR>
-```
-
-In the case of `nvim-tree`, there is an even simpler solution because it exposes an events API.
-You can add the following functions and then use `nvim-tree` mappings:
-
-```lua
-local nvim_tree_events = require('nvim-tree.events')
-local bufferline_api = require('bufferline.api')
-
-local function get_tree_size()
-  return require'nvim-tree.view'.View.width
-end
-
-nvim_tree_events.subscribe('TreeOpen', function()
-  bufferline_api.set_offset(get_tree_size())
-end)
-
-nvim_tree_events.subscribe('Resize', function()
-  bufferline_api.set_offset(get_tree_size())
-end)
-
-nvim_tree_events.subscribe('TreeClose', function()
-  bufferline_api.set_offset(0)
-end)
 ```
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -505,23 +505,30 @@ Add this autocmds to your configuration.
 
 ```lua
 local filetreename = 'neo-tree'
-vim.api.nvim_create_autocmd({ 'BufWinEnter', 'WinScrolled' }, {
-    callback = function(tbl)
-        if vim.bo[tbl.buf].filetype == filetreename then
-            local window_id = vim.fn.bufwinid(tbl.buf)
-            local width = vim.fn.winwidth(window_id)
-            require 'bufferline.api'.set_offset(width, 'FileTree')
+local function get_filetree_window()
+    for _, windowId in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local buffer = vim.api.nvim_win_get_buf(windowId)
+        if vim.api.nvim_buf_get_option(buffer, 'ft') == filetreename then
+            return windowId
         end
     end
-})
+    return nil
+end
 
-vim.api.nvim_create_autocmd({ 'BufWinLeave', 'BufWipeout' }, {
-    callback = function(tbl)
-        if vim.bo[tbl.buf].filetype == filetreename then
-            require 'bufferline.api'.set_offset(0)
-        end
+local function get_filetree_width()
+    local windowId = get_filetree_window()
+    if windowId == nil then return end
+    return vim.fn.winwidth(windowId)
+end
+
+vim.api.nvim_create_autocmd({ 'BufWinEnter', 'WinScrolled', 'BufWinLeave', 'BufWipeout' }, {
+    callback = function()
+        local width = get_filetree_width()
+        require('bufferline.api').set_offset(width or 0)
     end
 })
+end
+
 ```
 
 And add a mapping to use the above functions:


### PR DESCRIPTION
NvimTree and neo-tree are both resizable, this just shows how a user can get that information and use it.

fixes #373


[Screencast from 2023-03-02 17-21-53.webm](https://user-images.githubusercontent.com/61225/222353148-925d3bba-7b03-4754-b2c1-30df59c43f17.webm)

