### PR TITLE
perf: use API functions where possible

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -4,6 +4,7 @@ local bufnr = vim.fn.bufnr --- @type function
 local command = vim.api.nvim_command --- @type function
 local create_user_command = vim.api.nvim_create_user_command --- @type function
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
+local set_option = vim.api.nvim_set_option --- @type function
 
 local api = require'bufferline.api'
 local bbye = require'bufferline.bbye'
@@ -26,7 +27,7 @@ local bufferline = {}
 --- @return nil
 function bufferline.setup(user_config)
   -- Show the tabline
-  vim.opt.showtabline = 2
+  set_option('showtabline', 2)
 
   -- Create all necessary commands
   create_user_command('BarbarEnable', render.enable, {desc = 'Enable barbar.nvim'})

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -1,3 +1,5 @@
+local table_insert = table.insert
+
 local bufnr = vim.fn.bufnr --- @type function
 local command = vim.api.nvim_command --- @type function
 local create_user_command = vim.api.nvim_create_user_command --- @type function
@@ -57,7 +59,7 @@ function bufferline.setup(user_config)
         local buffer_indices = {}
 
         for i = 1, #buffers do
-          table.insert(buffer_indices, tostring(i))
+          table_insert(buffer_indices, tostring(i))
         end
 
         for i = -#buffers, -1 do

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -1,3 +1,4 @@
+local max = math.max
 local table_insert = table.insert
 
 local bufnr = vim.fn.bufnr --- @type function
@@ -35,13 +36,13 @@ function bufferline.setup(user_config)
 
   create_user_command(
     'BufferNext',
-    function(tbl) api.goto_buffer_relative(math.max(1, tbl.count)) end,
+    function(tbl) api.goto_buffer_relative(max(1, tbl.count)) end,
     {count = true, desc = 'Go to the next buffer'}
   )
 
   create_user_command(
     'BufferPrevious',
-    function(tbl) api.goto_buffer_relative(-math.max(1, tbl.count)) end,
+    function(tbl) api.goto_buffer_relative(-max(1, tbl.count)) end,
     {count = true, desc = 'Go to the previous buffer'}
   )
 
@@ -85,13 +86,13 @@ function bufferline.setup(user_config)
 
   create_user_command(
     'BufferMoveNext',
-    function(tbl) api.move_current_buffer(math.max(1, tbl.count)) end,
+    function(tbl) api.move_current_buffer(max(1, tbl.count)) end,
     {count = true, desc = 'Move the current buffer to the right'}
   )
 
   create_user_command(
     'BufferMovePrevious',
-    function(tbl) api.move_current_buffer(-math.max(1, tbl.count)) end,
+    function(tbl) api.move_current_buffer(-max(1, tbl.count)) end,
     {count = true, desc = 'Move the current buffer to the left'}
   )
 
@@ -180,13 +181,13 @@ function bufferline.setup(user_config)
 
   create_user_command(
     'BufferScrollLeft',
-    function(tbl) render.scroll(-math.max(1, tbl.count)) end,
+    function(tbl) render.scroll(-max(1, tbl.count)) end,
     {count = true, desc = 'Scroll the bufferline left'}
   )
 
   create_user_command(
     'BufferScrollRight',
-    function(tbl) render.scroll(math.max(1, tbl.count)) end,
+    function(tbl) render.scroll(max(1, tbl.count)) end,
     {count = true, desc = 'Scroll the bufferline right'}
   )
 

--- a/lua/bufferline/animate.lua
+++ b/lua/bufferline/animate.lua
@@ -4,6 +4,8 @@
 
 local floor = math.floor
 
+local schedule_wrap = vim.schedule_wrap
+
 --- @class bufferline.animate.state
 --- @field current number
 --- @field duration number
@@ -83,7 +85,6 @@ end
 --- @return bufferline.animate.state
 function animate.start(duration, initial, final, type, callback)
   local ticks = (duration / ANIMATION_FREQUENCY) + 10
-
   local state = {
     current = initial,
     duration = duration,
@@ -97,7 +98,10 @@ function animate.start(duration, initial, final, type, callback)
     type = type,
   }
 
-  state.timer:start(0, ANIMATION_FREQUENCY, vim.schedule_wrap(function() animate_tick(state) end))
+  state.timer:start(0, ANIMATION_FREQUENCY, schedule_wrap(function()
+    animate_tick(state)
+  end))
+
   state.fn(state.current, state)
   return state
 end

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -168,10 +168,10 @@ function api.goto_buffer(index)
   if index < 0 then
     index = #state.buffers + index + 1
   else
-    index = math.min(index, #state.buffers)
+    index = min(index, #state.buffers)
   end
 
-  index = math.max(1, index)
+  index = max(1, index)
 
   local buffer_number = state.buffers[index]
   if buffer_number then

--- a/lua/bufferline/bbye.lua
+++ b/lua/bufferline/bbye.lua
@@ -23,6 +23,8 @@
 -- For the full copy of the GNU Affero General Public License see:
 -- http://www.gnu.org/licenses.
 
+local buf_get_option = vim.api.nvim_buf_get_option --- @type function
+local buf_set_option = vim.api.nvim_buf_set_option --- @type function
 local buflisted = vim.fn.buflisted --- @type function
 local bufnr = vim.fn.bufnr --- @type function
 local command = vim.api.nvim_command --- @type function
@@ -31,6 +33,7 @@ local create_autocmd = vim.api.nvim_create_autocmd --- @type function
 local exec_autocmds = vim.api.nvim_exec_autocmds --- @type function
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local get_current_win = vim.api.nvim_get_current_win --- @type function
+local get_option = vim.api.nvim_get_option --- @type function
 local list_bufs = vim.api.nvim_list_bufs --- @type function
 local list_wins = vim.api.nvim_list_wins --- @type function
 local notify = vim.notify
@@ -38,8 +41,6 @@ local set_current_buf = vim.api.nvim_set_current_buf --- @type function
 local set_current_win = vim.api.nvim_set_current_win --- @type function
 local win_get_buf = vim.api.nvim_win_get_buf --- @type function
 local win_is_valid = vim.api.nvim_win_is_valid --- @type function
-local buf_get_option = vim.api.nvim_buf_get_option --- @type function
-local buf_set_option = vim.api.nvim_buf_set_option --- @type function
 
 local options = require'bufferline.options'
 local state = require'bufferline.state'
@@ -128,11 +129,11 @@ local function new(force)
 
   -- Regular buftype warns people if they have unsaved text there.
   -- Wouldn't want to lose someone's data:
-  vim.opt_local.buftype = ''
-  vim.opt_local.swapfile = false
+  buf_set_option(0, 'buftype', '')
+  buf_set_option(0, 'swapfile', false)
 
   -- If empty and out of sight, delete it right away:
-  vim.opt_local.bufhidden = 'wipe'
+  buf_set_option(0, 'bufhidden', 'wipe')
 
   create_autocmd('BufWipeout', {
     buffer = 0,
@@ -164,7 +165,7 @@ function bbye.delete(action, force, buffer, mods)
 
   local is_modified = buf_get_option(buffer_number, 'modified')
 
-  local has_confirm = vim.o.confirm
+  local has_confirm = get_option'confirm'
   if type(mods) == 'table' then
     has_confirm = has_confirm or mods.confirm
   elseif mods then

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -5,6 +5,7 @@
 local max = math.max
 local min = math.min
 local table_concat = table.concat
+local table_insert = table.insert
 
 local bufnr = vim.fn.bufnr --- @type function
 local buf_get_name = vim.api.nvim_buf_get_name --- @type function
@@ -164,7 +165,7 @@ local buffer = {
       hide = {hide.inactive, hide.visible, hide.alternate, hide.current}
       for _, buffer_number in ipairs(bufnrs) do
         if not hide[get_activity(buffer_number)] then
-          shown[#shown + 1] = buffer_number
+          table_insert(shown, buffer_number)
         end
       end
 

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -2,6 +2,8 @@
 -- get-icon.lua
 --
 
+local table_insert = table.insert
+
 local buf_get_name = vim.api.nvim_buf_get_name --- @type function
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
 local command = vim.api.nvim_command --- @type function
@@ -85,7 +87,7 @@ local icons = {
 
     if icon_hl and hlexists(icon_hl .. buffer_status) < 1 then
       hl_buffer_icon(buffer_status, icon_hl)
-      hl_groups[#hl_groups + 1] = { buffer_status = buffer_status, icon_hl = icon_hl }
+      table_insert(hl_groups, {buffer_status = buffer_status, icon_hl = icon_hl})
     end
 
     return icon_char, icon_hl .. buffer_status

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -8,6 +8,7 @@ local min = math.min
 local table_insert = table.insert
 
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
+local get_option = vim.api.nvim_get_option --- @type function
 local strwidth = vim.api.nvim_strwidth --- @type function
 local tabpagenr = vim.fn.tabpagenr --- @type function
 
@@ -115,7 +116,7 @@ end
 --- Calculate the current layout of the bufferline.
 --- @return bufferline.layout.data
 function Layout.calculate()
-  local available_width = vim.o.columns
+  local available_width = get_option'columns'
   available_width = available_width - state.offset.width
 
   local used_width, base_widths = Layout.calculate_buffers_width()

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -5,6 +5,7 @@
 local floor = math.floor
 local max = math.max
 local min = math.min
+local table_insert = table.insert
 
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
 local strwidth = vim.api.nvim_strwidth --- @type function
@@ -105,7 +106,7 @@ function Layout.calculate_buffers_width()
   for i, bufnr in ipairs(Layout.buffers) do
     local width = Layout.calculate_buffer_width(bufnr, i, render)
     sum = sum + width
-    widths[#widths + 1] = width
+    table_insert(widths, width)
   end
 
   return sum, widths

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -5,6 +5,7 @@
 local floor = math.floor
 local max = math.max
 local min = math.min
+local rshift = bit.rshift
 local table_insert = table.insert
 
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
@@ -126,7 +127,9 @@ function Layout.calculate()
 
   local remaining_width              = max(buffers_width - used_width, 0)
   local remaining_width_per_buffer   = floor(remaining_width / #base_widths)
-  local remaining_padding_per_buffer = floor(remaining_width_per_buffer / SIDES_OF_BUFFER)
+  -- PERF: faster than `floor(remaining_width_per_buffer / SIDES_OF_BUFFER)`.
+  --       if `SIDES_OF_BUFFER` changes, this will have to go back to `floor`.
+  local remaining_padding_per_buffer = rshift(remaining_width_per_buffer, 1)
   local padding_width                = max(options.minimum_padding(), min(remaining_padding_per_buffer, options.maximum_padding()))
   local actual_width                 = used_width + (#base_widths * padding_width * SIDES_OF_BUFFER)
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -19,12 +19,14 @@ local create_autocmd = vim.api.nvim_create_autocmd --- @type function
 local defer_fn = vim.defer_fn
 local exec_autocmds = vim.api.nvim_exec_autocmds --- @type function
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
+local get_option = vim.api.nvim_get_option --- @type function
 local has = vim.fn.has --- @type function
 local list_tabpages = vim.api.nvim_list_tabpages --- @type function
 local list_wins = vim.api.nvim_list_wins --- @type function
 local schedule = vim.schedule --- @type function
 local set_current_buf = vim.api.nvim_set_current_buf --- @type function
 local set_current_win = vim.api.nvim_set_current_win --- @type function
+local set_option = vim.api.nvim_set_option --- @type function
 local severity = vim.diagnostic.severity --- @type function
 local strcharpart = vim.fn.strcharpart --- @type function
 local strwidth = vim.api.nvim_strwidth --- @type function
@@ -235,7 +237,7 @@ end
 --- @return nil
 local function set_tabline(tabline)
   last_tabline = tabline
-  vim.opt.tabline = last_tabline
+  set_option('tabline', tabline or '')
 end
 
 --- @class bufferline.render
@@ -715,14 +717,14 @@ end
 local function generate_tabline(bufnrs, refocus)
   if options.auto_hide() then
     if #bufnrs + #list_tabpages() < 3 then -- 3 because the condition for auto-hiding is 1 visible buffer and 1 tabpage (2).
-      if vim.o.showtabline == 2 then
-        vim.o.showtabline = 0
+      if get_option'showtabline' == 2 then
+        set_option('showtabline', 0)
       end
       return
     end
 
-    if vim.o.showtabline == 0 then
-      vim.o.showtabline = 2
+    if get_option'showtabline' == 0 then
+      set_option('showtabline', 2)
     end
   end
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -480,6 +480,8 @@ function render.enable()
       local restore_cmd = vim.g.Bufferline__session_restore
       if restore_cmd then command(restore_cmd) end
 
+      -- TODO: I'm not sure if these two statements can be merged, but it's working now so I don't want to touch it.
+      vim.defer_fn(function() state.loading_session = false end, 100)
       schedule(function() render.update(true) end)
     end,
     group = augroup_bufferline_update,

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -24,6 +24,7 @@ local has = vim.fn.has --- @type function
 local list_tabpages = vim.api.nvim_list_tabpages --- @type function
 local list_wins = vim.api.nvim_list_wins --- @type function
 local schedule = vim.schedule --- @type function
+local schedule_wrap = vim.schedule_wrap
 local set_current_buf = vim.api.nvim_set_current_buf --- @type function
 local set_current_win = vim.api.nvim_set_current_win --- @type function
 local set_option = vim.api.nvim_set_option --- @type function
@@ -542,7 +543,7 @@ function render.enable()
   })
 
   create_autocmd('WinClosed', {
-    callback = function() schedule(render.update) end,
+    callback = schedule_wrap(render.update),
     group = augroup_bufferline_update,
   })
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -118,7 +118,7 @@ local function groups_insert(groups, position, others)
 
     -- While we haven't found the position...
     if current_position + group_width <= position then
-      new_groups[#new_groups + 1] = group
+      table_insert(new_groups, group)
       i = i + 1
       current_position = current_position + group_width
 
@@ -128,10 +128,10 @@ local function groups_insert(groups, position, others)
 
       -- Slice current group if it `position` is inside it
       if available_width > 0 then
-        new_groups[#new_groups + 1] = {
+        table_insert(new_groups, {
           text = strcharpart(group.text, 0, available_width),
           hl = group.hl,
-        }
+        })
       end
 
       -- Add new other groups
@@ -139,7 +139,7 @@ local function groups_insert(groups, position, others)
       for _, other in ipairs(others) do
         local other_width = strwidth(other.text)
         others_width = others_width + other_width
-        new_groups[#new_groups + 1] = other
+        table_insert(new_groups, other)
       end
 
       local end_position = position + others_width
@@ -156,14 +156,14 @@ local function groups_insert(groups, position, others)
           -- continue
         elseif previous_group_start_position >= end_position then
           -- table.insert(new_groups, 'direct')
-          new_groups[#new_groups + 1] = previous_group
+          table_insert(new_groups, previous_group)
         else
           local remaining_width = previous_group_end_position - end_position
           local start = previous_group_width - remaining_width
           local end_  = previous_group_width
           local new_group = { hl = previous_group.hl, text = strcharpart(previous_group.text, start, end_) }
           -- table.insert(new_groups, { group_start_position, group_end_position, end_position })
-          new_groups[#new_groups + 1] = new_group
+          table_insert(new_groups, new_group)
         end
 
         i = i + 1
@@ -193,11 +193,11 @@ local function slice_groups_right(groups, width)
     if accumulated_width >= width then
       local diff = text_width - (accumulated_width - width)
       local new_group = {hl = group.hl, text = strcharpart(group.text, 0, diff)}
-      new_groups[#new_groups + 1] = new_group
+      table_insert(new_groups, new_group)
       break
     end
 
-    new_groups[#new_groups + 1] = group
+    table_insert(new_groups, group)
   end
 
   return new_groups
@@ -477,15 +477,8 @@ function render.enable()
         return
       end
 
-      state.loading_session = true
-
-      if vim.g.Bufferline__session_restore then
-        command(vim.g.Bufferline__session_restore)
-      end
-
-      vim.fn.timer_start(100, function()
-        state.loading_session = false
-      end)
+      local restore_cmd = vim.g.Bufferline__session_restore
+      if restore_cmd then command(restore_cmd) end
 
       schedule(function() render.update(true) end)
     end,
@@ -530,13 +523,15 @@ function render.enable()
         -- escape quotes
         name = name:gsub('"', '\\"')
 
-        bufnames[#bufnames + 1] = '{' ..
+        table_insert(bufnames, '{' ..
           'name = "' .. name .. '",' ..
           'pinned = ' .. tostring(state.data_by_bufnr[bufnr].pinned == true) .. ',' ..
-        '}'
+        '}')
       end
 
-      vim.g.Bufferline__session_restore = "lua require'bufferline.state'.restore_buffers {" .. table_concat(bufnames, ',') .. "}"
+      vim.g.Bufferline__session_restore = "lua require'bufferline.state'.restore_buffers {" ..
+        table_concat(bufnames, ',') ..
+      "}"
     end,
     group = augroup_bufferline,
     pattern = 'SessionSavePre',
@@ -889,7 +884,7 @@ local function generate_tabline(bufnrs, refocus)
       end
     end
 
-    items[#items + 1] = item
+    table_insert(items, item)
     current_buffer_position = current_buffer_position + item.width
   end
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -676,7 +676,7 @@ end
 --- @param n integer the amount to scroll by. Use negative numbers to scroll left, and positive to scroll right.
 --- @return nil
 function render.scroll(n)
-  render.set_scroll(math.max(0, scroll.target + n))
+  render.set_scroll(max(0, scroll.target + n))
 end
 
 local scroll_animation = nil

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -2,6 +2,7 @@
 -- m.lua
 --
 
+local table_insert = table.insert
 local table_remove = table.remove
 
 local buf_get_name = vim.api.nvim_buf_get_name --- @type function
@@ -87,7 +88,7 @@ function state.get_buffer_list()
     then
       local name = buf_get_name(bufnr)
       if not utils.has(exclude_name, utils.basename(name, hide_extensions)) then
-        table.insert(result, bufnr)
+        table_insert(result, bufnr)
       end
     end
   end
@@ -114,7 +115,7 @@ function state.sort_pins_to_left()
     if state.is_pinned(state.buffers[i]) then
       i = i + 1
     else
-      unpinned[#unpinned + 1] = table_remove(state.buffers, i)
+      table_insert(unpinned, table_remove(state.buffers, i))
     end
   end
 
@@ -203,8 +204,6 @@ end
 --- @param buffer_data string[]|{name: string, pinned: boolean}[]
 --- @return nil
 function state.restore_buffers(buffer_data)
-  --- PERF: since this function is only run once (`nvim -S`) I avoided importing the called functions at top-level
-  local table_insert = table.insert
   local buf_delete = vim.api.nvim_buf_delete
   local buf_get_lines = vim.api.nvim_buf_get_lines
   local buf_line_count = vim.api.nvim_buf_line_count

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -2,6 +2,8 @@
 -- utils.lua
 --
 
+local table_insert = table.insert
+
 local fnamemodify = vim.fn.fnamemodify --- @type function
 local get_hl_by_name = vim.api.nvim_get_hl_by_name --- @type function
 local hlexists = vim.fn.hlexists --- @type function
@@ -173,7 +175,7 @@ local utils = {
   reverse = function(list)
     local reversed = {}
     for i = #list, 1, -1 do
-      table.insert(reversed, list[i])
+      table_insert(reversed, list[i])
     end
     return reversed
   end,


### PR DESCRIPTION
I've discovered that there are certain cases where API functions offer a distinct speed advantage over their `vim`-namespace counterparts, and takes advantage of that.

I want to test this for a while before merging.