### PR TITLE
docs: always specify `@return`

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -4,26 +4,13 @@ local create_user_command = vim.api.nvim_create_user_command
 local get_current_buf = vim.api.nvim_get_current_buf
 local notify = vim.notify
 
---- @type bufferline.api
-local api = require'bufferline.api'
-
---- @type bbye
-local bbye = require'bufferline.bbye'
-
---- @type bufferline.highlight
-local highlight = require'bufferline.highlight'
-
---- @type bufferline.JumpMode
-local JumpMode = require'bufferline.jump_mode'
-
---- @type bufferline.options
-local options = require'bufferline.options'
-
---- @type bufferline.render
-local render = require'bufferline.render'
-
---- @type bufferline.state
-local state = require'bufferline.state'
+local api = require'bufferline.api' --- @type bufferline.api
+local bbye = require'bufferline.bbye' --- @type bbye
+local highlight = require'bufferline.highlight' --- @type bufferline.highlight
+local JumpMode = require'bufferline.jump_mode' --- @type bufferline.JumpMode
+local options = require'bufferline.options' --- @type bufferline.options
+local render = require'bufferline.render' --- @type bufferline.render
+local state = require'bufferline.state' --- @type bufferline.state
 
 -------------------------------
 -- Section: `bufferline` module
@@ -34,6 +21,7 @@ local bufferline = {}
 
 --- Setup this plugin.
 --- @param user_config? table
+--- @return nil
 function bufferline.setup(user_config)
   -- Show the tabline
   vim.opt.showtabline = 2

--- a/lua/bufferline/animate.lua
+++ b/lua/bufferline/animate.lua
@@ -4,6 +4,18 @@
 
 local floor = math.floor
 
+--- @class bufferline.animate.state
+--- @field current number
+--- @field duration number
+--- @field final number
+--- @field fn fun(current: number, state: self)
+--- @field initial number
+--- @field running boolean
+--- @field start number
+--- @field step number
+--- @field timer userdata
+--- @field type unknown
+
 --- @class bufferline.animate
 local animate = {}
 
@@ -20,6 +32,10 @@ local function time(start)
   return t
 end
 
+--- @param ratio number
+--- @param initial number
+--- @param final number
+--- @return number
 function animate.lerp(ratio, initial, final, delta_type)
   delta_type = delta_type or vim.v.t_number
 
@@ -29,6 +45,8 @@ function animate.lerp(ratio, initial, final, delta_type)
   return initial + delta
 end
 
+--- @param state bufferline.animate.state
+--- @return nil
 local function animate_tick(state)
   -- Alternative to finding current value:
   --
@@ -57,20 +75,27 @@ local function animate_tick(state)
   end
 end
 
+--- @param callback fun(current: number, state: bufferline.animate.state)
+--- @param duration number
+--- @param final number
+--- @param initial number
+--- @param type unknown
+--- @return bufferline.animate.state
 function animate.start(duration, initial, final, type, callback)
   local ticks = (duration / ANIMATION_FREQUENCY) + 10
 
-  local state = {}
-  state.running = true
-  state.fn = callback
-  state.type = type
-  state.step = (final - initial) / ticks
-  state.duration = duration
-  state.current = initial
-  state.initial = initial
-  state.final = final
-  state.start = time()
-  state.timer = vim.loop.new_timer()
+  local state = {
+    current = initial,
+    duration = duration,
+    final = final,
+    fn = callback,
+    initial = initial,
+    running = true,
+    start = time(),
+    step = (final - initial) / ticks,
+    timer = vim.loop.new_timer(),
+    type = type,
+  }
 
   state.timer:start(0, ANIMATION_FREQUENCY, vim.schedule_wrap(function()
     animate_tick(state)
@@ -80,6 +105,8 @@ function animate.start(duration, initial, final, type, callback)
   return state
 end
 
+--- @param state bufferline.animate.state
+--- @return nil
 function animate.stop(state)
   if state.timer then
     state.timer:stop()

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -17,37 +17,21 @@ local set_current_buf = vim.api.nvim_set_current_buf
 -- TODO: remove `vim.fs and` after 0.8 release
 local normalize = vim.fs and vim.fs.normalize
 
---- @type bufferline.animate
-local animate = require'bufferline.animate'
-
---- @type bbye
-local bbye = require'bufferline.bbye'
-
---- @type bufferline.JumpMode
-local JumpMode = require'bufferline.jump_mode'
-
---- @type bufferline.Layout
-local Layout = require'bufferline.layout'
-
---- @type bufferline.options
-local options = require'bufferline.options'
-
---- @type bufferline.render
-local render = require'bufferline.render'
-
---- @type bufferline.state
-local state = require'bufferline.state'
-
---- @type bufferline.utils
-local utils = require'bufferline.utils'
-
---- @type bufferline.buffer
-local Buffer = require'bufferline.buffer'
+local animate = require'bufferline.animate' --- @type bufferline.animate
+local bbye = require'bufferline.bbye' --- @type bbye
+local Buffer = require'bufferline.buffer' --- @type bufferline.buffer
+local JumpMode = require'bufferline.jump_mode' --- @type bufferline.JumpMode
+local Layout = require'bufferline.layout' --- @type bufferline.Layout
+local options = require'bufferline.options' --- @type bufferline.options
+local render = require'bufferline.render' --- @type bufferline.render
+local state = require'bufferline.state' --- @type bufferline.state
+local utils = require'bufferline.utils' --- @type bufferline.utils
 
 local ESC = vim.api.nvim_replace_termcodes('<Esc>', true, false, true)
 
 --- Initialize the buffer pick mode.
 --- @param fn fun()
+--- @return nil
 local function pick_buffer_wrap(fn)
   if JumpMode.reinitialize then
     JumpMode.initialize_indexes()
@@ -66,6 +50,7 @@ end
 
 --- Shows an error that `bufnr` was not among the `state.buffers`
 --- @param bufnr integer
+--- @return nil
 local function notify_buffer_not_found(bufnr)
   notify(
     'Current buffer (' .. bufnr .. ") not found in bufferline.nvim's list of buffers: " .. vim.inspect(state.buffers),
@@ -96,6 +81,7 @@ end
 local api = {}
 
 --- Close all open buffers, except the current one.
+--- @return nil
 function api.close_all_but_current()
   local current_bufnr = get_current_buf()
 
@@ -109,6 +95,7 @@ function api.close_all_but_current()
 end
 
 --- Close all open buffers, except those in visible windows.
+--- @return nil
 function api.close_all_but_visible()
   for _, bufnr in ipairs(state.buffers) do
     if Buffer.get_activity(bufnr) < 3 then
@@ -120,6 +107,7 @@ function api.close_all_but_visible()
 end
 
 --- Close all open buffers, except pinned ones.
+--- @return nil
 function api.close_all_but_pinned()
   for _, bufnr in ipairs(state.buffers) do
     if not state.is_pinned(bufnr) then
@@ -131,6 +119,7 @@ function api.close_all_but_pinned()
 end
 
 --- Close all open buffers, except pinned ones or the current one.
+--- @return nil
 function api.close_all_but_current_or_pinned()
   local current_bufnr = get_current_buf()
 
@@ -144,6 +133,7 @@ function api.close_all_but_current_or_pinned()
 end
 
 --- Close all buffers which are visually left of the current buffer.
+--- @return nil
 function api.close_buffers_left()
   local idx = utils.index_of(state.buffers, get_current_buf())
   if idx == nil or idx == 1 then
@@ -158,6 +148,7 @@ function api.close_buffers_left()
 end
 
 --- Close all buffers which are visually right of the current buffer.
+--- @return nil
 function api.close_buffers_right()
   local idx = utils.index_of(state.buffers, get_current_buf())
   if idx == nil then
@@ -173,6 +164,7 @@ end
 
 --- Set the current buffer to the `number`
 --- @param index integer
+--- @return nil
 function api.goto_buffer(index)
   if index < 0 then
     index = #state.buffers + index + 1
@@ -186,6 +178,7 @@ end
 --- Go to the buffer a certain number of buffers away from the current buffer.
 --- Use a positive number to go "right", and a negative one to go "left".
 --- @param steps integer
+--- @return nil
 function api.goto_buffer_relative(steps)
   render.get_updated_buffers()
 
@@ -207,6 +200,7 @@ local move_animation = nil
 local move_animation_data = nil
 
 --- An incremental animation for `move_buffer_animated`.
+--- @return nil
 local function move_buffer_animated_tick(ratio, current_animation)
   local data = move_animation_data
 
@@ -234,9 +228,11 @@ local function move_buffer_animated_tick(ratio, current_animation)
 end
 
 local MOVE_DURATION = 150
+
 --- Move a buffer (with animation, if configured).
 --- @param from_idx integer the buffer's original index.
 --- @param to_idx integer the buffer's new index.
+--- @return nil
 local function move_buffer(from_idx, to_idx)
   to_idx = max(1, min(#state.buffers, to_idx))
   if to_idx == from_idx then
@@ -295,6 +291,7 @@ end
 
 --- Move the current buffer to the index specified.
 --- @param idx integer
+--- @return nil
 function api.move_current_buffer_to(idx)
   render.update()
 
@@ -315,6 +312,7 @@ end
 
 --- Move the current buffer a certain number of times over.
 --- @param steps integer
+--- @return nil
 function api.move_current_buffer(steps)
   render.update()
 
@@ -330,12 +328,14 @@ function api.move_current_buffer(steps)
 end
 
 --- Order the buffers by their buffer number.
+--- @return nil
 function api.order_by_buffer_number()
   table_sort(state.buffers, function(a, b) return a < b end)
   render.update()
 end
 
 --- Order the buffers by their parent directory.
+--- @return nil
 function api.order_by_directory()
   table_sort(state.buffers, with_pin_order(function(a, b)
     local name_of_a = buf_get_name(a)
@@ -366,6 +366,7 @@ function api.order_by_directory()
 end
 
 --- Order the buffers by filetype.
+--- @return nil
 function api.order_by_language()
   table_sort(state.buffers, with_pin_order(function(a, b)
     return buf_get_option(a, 'filetype') < buf_get_option(b, 'filetype')
@@ -375,6 +376,7 @@ function api.order_by_language()
 end
 
 --- Order the buffers by their respective window number.
+--- @return nil
 function api.order_by_window_number()
   table_sort(state.buffers, with_pin_order(function(a, b)
     return bufwinnr(buf_get_name(a)) < bufwinnr(buf_get_name(b))
@@ -384,6 +386,7 @@ function api.order_by_window_number()
 end
 
 --- Activate the buffer pick mode.
+--- @return nil
 function api.pick_buffer()
   pick_buffer_wrap(function()
     local ok, byte = pcall(getchar)
@@ -404,6 +407,7 @@ function api.pick_buffer()
 end
 
 --- Activate the buffer pick delete mode.
+--- @return nil
 function api.pick_buffer_delete()
   pick_buffer_wrap(function()
     while true do
@@ -434,6 +438,7 @@ end
 --- @param width integer the amount to offset
 --- @param text? string text to put in the offset
 --- @param hl? string
+--- @return nil
 function api.set_offset(width, text, hl)
   state.offset = width > 0 and
     {hl = hl, text = text or '', width = width} or
@@ -444,6 +449,7 @@ end
 
 --- Toggle the `bufnr`'s "pin" state, visually.
 --- @param bufnr? integer
+--- @return nil
 function api.toggle_pin(bufnr)
   state.toggle_pin(bufnr or 0)
   render.update()

--- a/lua/bufferline/bbye.lua
+++ b/lua/bufferline/bbye.lua
@@ -40,11 +40,8 @@ local win_is_valid = vim.api.nvim_win_is_valid
 local buf_get_option = vim.api.nvim_buf_get_option
 local buf_set_option = vim.api.nvim_buf_set_option
 
---- @type bufferline.state
-local state = require'bufferline.state'
-
---- @type bufferline.utils
-local utils = require'bufferline.utils'
+local state = require'bufferline.state' --- @type bufferline.state
+local utils = require'bufferline.utils' --- @type bufferline.utils
 
 -------------------
 -- Section: helpers
@@ -68,6 +65,7 @@ local cmd = vim.api.nvim_cmd and
 
 --- Use `vim.notify` to print an error `msg`
 --- @param msg string
+--- @return nil
 local function err(msg)
   notify(msg, vim.log.levels.ERROR, {title = 'bbye'})
   vim.v.errmsg = msg
@@ -77,6 +75,7 @@ local empty_buffer = nil
 
 --- Create a new buffer.
 --- @param force boolean if `true`, forcefully create the new buffer
+--- @return nil
 local function new(force)
   command("enew" .. (force and '!' or ''))
 
@@ -111,6 +110,7 @@ local bbye = {}
 --- @param buffer? integer|string the name of the buffer.
 --- @param mods? string|{[string]: any} the modifiers to the command (e.g. `'verbose'`)
 --- @param focus_id? number the preferred buffer to focus
+--- @return nil
 function bbye.delete(action, force, buffer, mods, focus_id)
   local buffer_number = type(buffer) == 'string' and bufnr(buffer) or tonumber(buffer) or get_current_buf()
 
@@ -202,6 +202,7 @@ end
 --- @param buffer? integer|string the name of the buffer.
 --- @param mods? string|{[string]: any} the modifiers to the command (e.g. `'verbose'`)
 --- @param focus_id? number the preferred buffer to focus
+--- @return nil
 function bbye.bdelete(force, buffer, mods, focus_id)
   bbye.delete('bdelete', force, buffer, mods, focus_id)
 end
@@ -211,6 +212,7 @@ end
 --- @param buffer? integer|string the name of the buffer.
 --- @param mods? string|{[string]: any} the modifiers to the command (e.g. `'verbose'`)
 --- @param focus_id? number the preferred buffer to focus
+--- @return nil
 function bbye.bwipeout(force, buffer, mods, focus_id)
   bbye.delete('bwipeout', force, buffer, mods, focus_id)
 end

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -22,11 +22,8 @@ local strcharpart = vim.fn.strcharpart
 local strwidth = vim.api.nvim_strwidth
 local WARN = vim.diagnostic.severity.WARN
 
---- @type bufferline.options
-local options = require'bufferline.options'
-
---- @type bufferline.utils
-local utils = require'bufferline.utils'
+local options = require'bufferline.options' --- @type bufferline.options
+local utils = require'bufferline.utils' --- @type bufferline.utils
 
 --- @alias bufferline.buffer.activity 1|2|3|4
 
@@ -61,7 +58,7 @@ local function get_activity(buffer_number)
 end
 
 --- @param buffer_number number
---- @return {[number]: number} count keyed on `vim.diagnostic.severity`
+--- @return number[] # indexed on `vim.diagnostic.severity`
 local function count_diagnostics(buffer_number)
   local count = {[ERROR] = 0, [HINT] = 0, [INFO] = 0, [WARN] = 0}
 
@@ -80,13 +77,14 @@ return {
   --- @param buffer_number integer the buffer number to count diagnostics in
   --- @param diagnostics bufferline.options.diagnostics the user configuration for diagnostics
   --- @param f fun(count: integer, diagnostic: bufferline.options.diagnostics.severity, severity: integer) the function to run when diagnostics of a specific severity are enabled and present in the `buffer_number`
+  --- @return nil
   for_each_counted_enabled_diagnostic = function(buffer_number, diagnostics, f)
     local count
-    for i, v in ipairs(diagnostics) do
-      if v.enabled then
+    for severity, severity_config in ipairs(diagnostics) do
+      if severity_config.enabled then
         count = count or count_diagnostics(buffer_number)
-        if count[i] > 0 then
-          f(count[i], v, i)
+        if count[severity] > 0 then
+          f(count[severity], severity_config, severity)
         end
       end
     end
@@ -155,9 +153,9 @@ return {
   end,
 
   --- Filter buffer numbers which are not to be shown during the render process.
-  --- Does not mutate `bufnrs`.
+  --- Does **not** mutate `bufnrs`.
   --- @param bufnrs integer[]
-  --- @return integer[] bufnrs
+  --- @return integer[] bufnrs the shown buffers
   hide = function(bufnrs)
     local hide = options.hide()
     if hide.alternate or hide.current or hide.inactive or hide.visible then

--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -69,11 +69,11 @@ hl.set_default_link('BufferDefaultOffset', 'BufferTabpageFill')
 --- @class bufferline.highlight
 return {
   --- Setup the highlight groups for this plugin.
+  --- @return nil
   setup = function()
     local fg_current = hl.fg_or_default({'Normal'}, '#efefef', 255)
     local fg_inactive = hl.fg_or_default({'TabLineFill'}, '#888888', 102)
-    --- @type barbar.utils.hl.group
-    local fg_target = {gui = 'red'}
+    local fg_target = {gui = 'red'} --- @type barbar.utils.hl.group
     fg_target.cterm = fg_target.gui
 
     local fg_error = hl.fg_or_default({'ErrorMsg'}, '#A80000', 124)

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -9,8 +9,7 @@ local fnamemodify = vim.fn.fnamemodify
 local hlexists = vim.fn.hlexists
 local notify = vim.notify
 
---- @type bufferline.utils.hl
-local hl = require'bufferline.utils'.hl
+local hl = require'bufferline.utils'.hl --- @type bufferline.utils.hl
 
 --- @type boolean, {get_icon: fun(name: string, ext?: string, opts?: {default: nil|boolean}): string, string}
 local status, web = pcall(require, 'nvim-web-devicons')
@@ -25,6 +24,7 @@ local hl_groups = {}
 --- Sets the highlight group used for a type of buffer's file icon
 --- @param buffer_status bufferline.buffer.activity.name
 --- @param icon_hl string
+--- @return nil
 local function hl_buffer_icon(buffer_status, icon_hl)
   hl.set(
     icon_hl .. buffer_status,
@@ -35,14 +35,13 @@ end
 
 --- @class bufferline.icons
 return {
-  -- It's not possible to purely delete an HL group when the colorscheme
-  -- changes, therefore we need to re-define colors for all groups we have
-  -- already highlighted.
+  --- Re-highlight all of the groups which have been set before. Checks for updated highlight groups.
+  --- @return nil
   set_highlights = function()
     for _, group in ipairs(hl_groups) do
       hl_buffer_icon(group.buffer_status, group.icon_hl)
     end
- end,
+  end,
 
   --- @param bufnr integer
   --- @param buffer_status bufferline.buffer.activity.name

--- a/lua/bufferline/jump_mode.lua
+++ b/lua/bufferline/jump_mode.lua
@@ -8,8 +8,7 @@ local split = vim.fn.split
 local strcharpart = vim.fn.strcharpart
 local strwidth = vim.api.nvim_strwidth
 
---- @type bufferline.options
-local options = require'bufferline.options'
+local options = require'bufferline.options' --- @type bufferline.options
 
 ----------------------------------------
 -- Section: Buffer-picking mode state --
@@ -28,6 +27,7 @@ local letters = {}
 local JumpMode = {}
 
 --- Reset the module to a valid default state
+--- @return nil
 function JumpMode.initialize_indexes()
   JumpMode.buffer_by_letter = {}
   JumpMode.index_by_letter = {}
@@ -44,12 +44,11 @@ end
 
 --- Set the letters which can be used by jump mode.
 --- @param chars string
+--- @return nil
 function JumpMode.set_letters(chars)
   letters = split(chars, [[\zs]])
   JumpMode.initialize_indexes()
 end
-
--- local empty_bufnr = vim.api.nvim_create_buf(0, 1)
 
 --- @param bufnr integer
 --- @return nil|string assigned
@@ -98,6 +97,7 @@ function JumpMode.get_letter(bufnr)
 end
 
 --- @param letter string
+--- @return nil
 function JumpMode.unassign_letter(letter)
   if letter == '' or letter == nil then
     return
@@ -118,6 +118,7 @@ end
 
 --- Unassign the letter which is assigned to `bufnr.`
 --- @param bufnr integer
+--- @return nil
 function JumpMode.unassign_letter_for(bufnr)
   JumpMode.unassign_letter(JumpMode.letter_by_buffer[bufnr])
 end

--- a/lua/bufferline/layout.lua
+++ b/lua/bufferline/layout.lua
@@ -10,17 +10,10 @@ local buf_get_option = vim.api.nvim_buf_get_option
 local strwidth = vim.api.nvim_strwidth
 local tabpagenr = vim.fn.tabpagenr
 
---- @type bufferline.buffer
-local Buffer = require'bufferline.buffer'
-
---- @type bufferline.icons
-local icons = require'bufferline.icons'
-
---- @type bufferline.options
-local options = require'bufferline.options'
-
---- @type bufferline.state
-local state = require'bufferline.state'
+local Buffer = require'bufferline.buffer' --- @type bufferline.buffer
+local icons = require'bufferline.icons' --- @type bufferline.icons
+local options = require'bufferline.options' --- @type bufferline.options
+local state = require'bufferline.state' --- @type bufferline.state
 
 --- The number of sides of each buffer in the tabline.
 local SIDES_OF_BUFFER = 2

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -35,35 +35,16 @@ local tbl_contains = vim.tbl_contains
 local tbl_filter = vim.tbl_filter
 local win_get_buf = vim.api.nvim_win_get_buf
 
---- @type bufferline.animate
-local animate = require'bufferline.animate'
-
---- @type bbye
-local bbye = require'bufferline.bbye'
-
---- @type bufferline.buffer
-local Buffer = require'bufferline.buffer'
-
---- @type bufferline.highlight
-local highlight = require'bufferline.highlight'
-
---- @type bufferline.icons
-local icons = require'bufferline.icons'
-
---- @type bufferline.JumpMode
-local JumpMode = require'bufferline.jump_mode'
-
---- @type bufferline.Layout
-local Layout = require'bufferline.layout'
-
---- @type bufferline.options
-local options = require'bufferline.options'
-
---- @type bufferline.state
-local state = require'bufferline.state'
-
---- @type bufferline.utils
-local utils = require'bufferline.utils'
+local animate = require'bufferline.animate' --- @type bufferline.animate
+local bbye = require'bufferline.bbye' --- @type bbye
+local Buffer = require'bufferline.buffer' --- @type bufferline.buffer
+local highlight = require'bufferline.highlight' --- @type bufferline.highlight
+local icons = require'bufferline.icons' --- @type bufferline.icons
+local JumpMode = require'bufferline.jump_mode' --- @type bufferline.JumpMode
+local Layout = require'bufferline.layout' --- @type bufferline.Layout
+local options = require'bufferline.options' --- @type bufferline.options
+local state = require'bufferline.state' --- @type bufferline.state
+local utils = require'bufferline.utils' --- @type bufferline.utils
 
 --- The highlight to use based on the state of a buffer.
 local HL_BY_ACTIVITY = {'Inactive', 'Alternate', 'Visible', 'Current'}
@@ -200,6 +181,7 @@ end
 --- Select from `groups` while fitting within the provided `width`, discarding all indices larger than the last index that fits.
 --- @param groups bufferline.render.group[]
 --- @param width integer
+--- @return bufferline.render.group[]
 local function slice_groups_right(groups, width)
   local accumulated_width = 0
 
@@ -225,6 +207,7 @@ end
 --- Select from `groups` in reverse while fitting within the provided `width`, discarding all indices less than the last index that fits.
 --- @param groups bufferline.render.group[]
 --- @param width integer
+--- @return bufferline.render.group[]
 local function slice_groups_left(groups, width)
   local accumulated_width = 0
 
@@ -250,6 +233,7 @@ end
 
 --- Clears the tabline. Does not stop the tabline from being redrawn via autocmd.
 --- @param tabline? string
+--- @return nil
 local function set_tabline(tabline)
   last_tabline = tabline
   vim.opt.tabline = last_tabline
@@ -261,6 +245,7 @@ local render = {}
 --- An incremental animation for `close_buffer_animated`.
 --- @param bufnr integer
 --- @param new_width integer
+--- @return nil
 local function close_buffer_animated_tick(bufnr, new_width, animation)
   if new_width > 0 and state.data_by_bufnr[bufnr] ~= nil then
     local buffer_data = state.get_buffer_data(bufnr)
@@ -276,6 +261,7 @@ end
 --- WARN: does NOT close the buffer in Neovim (see `:h nvim_buf_delete`)
 --- @param bufnr integer
 --- @param do_name_update? boolean refreshes all buffer names iff `true`
+--- @return nil
 function render.close_buffer(bufnr, do_name_update)
   state.close_buffer(bufnr, do_name_update)
   render.update()
@@ -283,6 +269,7 @@ end
 
 --- Same as `close_buffer`, but animated.
 --- @param bufnr integer
+--- @return nil
 function render.close_buffer_animated(bufnr)
   if options.animation() == false then
     return render.close_buffer(bufnr)
@@ -303,6 +290,7 @@ end
 
 --- What to do when clicking a buffer close button.
 --- @param buffer integer
+--- @return nil
 function render.close_click_handler(buffer)
   if buf_get_option(buffer, 'modified') then
     buf_call(buffer, function() command('w') end)
@@ -313,6 +301,7 @@ function render.close_click_handler(buffer)
 end
 
 --- Disable the bufferline
+--- @return nil
 function render.disable()
   create_augroups()
   set_tabline(nil)
@@ -327,6 +316,7 @@ end
 --- @param bufnr integer
 --- @param new_width integer
 --- @param animation unknown
+--- @return nil
 local function open_buffer_animated_tick(bufnr, new_width, animation)
   local buffer_data = state.get_buffer_data(bufnr)
   buffer_data.width = animation.running and new_width or nil
@@ -337,6 +327,7 @@ end
 --- Opens a buffer with animation.
 --- @param bufnr integer
 --- @param layout bufferline.layout.data
+--- @return nil
 local function open_buffer_start_animation(layout, bufnr)
   local buffer_data = state.get_buffer_data(bufnr)
   local icons_option = options.icons()
@@ -366,6 +357,7 @@ local function open_buffer_start_animation(layout, bufnr)
 end
 
 --- Open the `new_buffers` in the bufferline.
+--- @return nil
 local function open_buffers(new_buffers)
   local initial_buffers = #state.buffers
 
@@ -428,6 +420,7 @@ local function open_buffers(new_buffers)
 end
 
 --- Enable the bufferline.
+--- @return nil
 function render.enable()
   local augroup_bufferline, augroup_bufferline_update = create_augroups()
 
@@ -579,6 +572,7 @@ function render.enable()
 end
 
 --- Refresh the buffer list.
+--- @return integer[] state.buffers
 function render.get_updated_buffers(update_names)
   local current_buffers = state.get_buffer_list()
   local new_buffers =
@@ -624,6 +618,7 @@ end
 --- What to do when clicking a buffer label.
 --- @param bufnr integer the buffer nummber
 --- @param btn string
+--- @return nil
 function render.main_click_handler(bufnr, _, btn, _)
   if bufnr == 0 then
     return
@@ -640,6 +635,7 @@ end
 
 --- What to do when `vim.g.bufferline` is changed.
 --- @param key string what option was changed.
+--- @return nil
 function render.on_option_changed(_, key, _)
   if vim.g.bufferline and key == 'letters' then
     JumpMode.set_letters(options.letters())
@@ -679,6 +675,7 @@ end
 
 --- Scroll the bufferline relative to its current position.
 --- @param n integer the amount to scroll by. Use negative numbers to scroll left, and positive to scroll right.
+--- @return nil
 function render.scroll(n)
   render.set_scroll(math.max(0, scroll.target + n))
 end
@@ -686,6 +683,7 @@ end
 local scroll_animation = nil
 
 --- An incremental animation for `set_scroll`.
+--- @return nil
 local function set_scroll_tick(new_scroll, animation)
   scroll.current = new_scroll
   if animation.running == false then
@@ -696,6 +694,7 @@ end
 
 --- Scrolls the bufferline to the `target`.
 --- @param target integer where to scroll to
+--- @return nil
 function render.set_scroll(target)
   scroll.target = target
 
@@ -963,6 +962,7 @@ end
 --- Update `&tabline`
 --- @param refocus? boolean if `true`, the bufferline will be refocused on the current buffer (default: `true`)
 --- @param update_names? boolean whether to refresh the names of the buffers (default: `false`)
+--- @return nil
 function render.update(update_names, refocus)
   if vim.g.SessionLoad then
     return

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -12,14 +12,9 @@ local list_bufs = vim.api.nvim_list_bufs
 local list_extend = vim.list_extend
 local tbl_filter = vim.tbl_filter
 
---- @type bufferline.buffer
-local Buffer = require'bufferline.buffer'
-
---- @type bufferline.options
-local options = require'bufferline.options'
-
---- @type bufferline.utils
-local utils = require'bufferline.utils'
+local Buffer = require'bufferline.buffer' --- @type bufferline.buffer
+local options = require'bufferline.options' --- @type bufferline.options
+local utils = require'bufferline.utils' --- @type bufferline.utils
 
 --------------------------------
 -- Section: Application state --
@@ -78,6 +73,7 @@ function state.get_buffer_data(bufnr)
 end
 
 --- Get the list of buffers
+--- @return integer[] bufnrs
 function state.get_buffer_list()
   local buffers = list_bufs()
   local result = {}
@@ -111,6 +107,7 @@ function state.is_pinned(bufnr)
 end
 
 --- Sort the pinned tabs to the left of the bufferline.
+--- @return nil
 function state.sort_pins_to_left()
   local unpinned = {}
 
@@ -129,6 +126,7 @@ end
 --- Toggle the `bufnr`'s "pin" state.
 --- WARN: does not redraw the bufferline. See `Render.toggle_pin`.
 --- @param bufnr integer
+--- @return nil
 function state.toggle_pin(bufnr)
   local data = state.get_buffer_data(bufnr)
   data.pinned = not data.pinned
@@ -142,6 +140,7 @@ end
 --- WARN: does NOT close the buffer in Neovim (see `:h nvim_buf_delete`)
 --- @param bufnr integer
 --- @param do_name_update? boolean refreshes all buffer names iff `true`
+--- @return nil
 function state.close_buffer(bufnr, do_name_update)
   state.buffers = tbl_filter(function(b) return b ~= bufnr end, state.buffers)
   state.data_by_bufnr[bufnr] = nil
@@ -174,6 +173,7 @@ function state.find_next_buffer(buffer_number)
 end
 
 --- Update the names of all buffers in the bufferline.
+--- @return nil
 function state.update_names()
   local buffer_index_by_name = {}
   local hide_extensions = options.hide().extensions
@@ -207,6 +207,7 @@ end
 --- @param width integer
 --- @param text? string
 --- @param hl? string
+--- @return nil
 function state.set_offset(width, text, hl)
   if vim.deprecate then
     vim.deprecate('`bufferline.state.set_offset`', '`bufferline.api.set_offset`', '2.0.0', 'barbar.nvim')
@@ -223,6 +224,7 @@ end
 
 --- Restore the buffers
 --- @param buffer_data string[]|{name: string, pinned: boolean}[]
+--- @return nil
 function state.restore_buffers(buffer_data)
   --- PERF: since this function is only run once (`nvim -S`) I avoided importing the called functions at top-level
   local table_insert = table.insert

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -41,7 +41,7 @@ local function index_of(list, t)
   return nil
 end
 
-  --- @param path string
+--- @param path string
 --- @return string relative_path
 local function relative(path)
   return fnamemodify(path, ':~:.')
@@ -107,6 +107,7 @@ return {
     --- @param bg barbar.utils.hl.group
     --- @param fg barbar.utils.hl.group
     --- @param bold? boolean whether the highlight group should be bolded
+    --- @return nil
     set = function(group, bg, fg, bold)
       set_hl(0, group, {
         bold = bold,
@@ -122,7 +123,8 @@ return {
     --- Set the default highlight `group_name` as a link to `link_name`
     --- @param group_name string the name of the group to by-default be linked to `link_name`
     --- @param link_name string the name of the group to by-default link `group_name` to
-    set_default_link = function (group_name, link_name)
+    --- @return nil
+    set_default_link = function(group_name, link_name)
       set_hl(0, group_name, {default = true, link = link_name})
     end,
   },


### PR DESCRIPTION
This makes it so that we don't accidentally do something like this:

```lua
--- @return nil
local function foo()
  return true
end

--- @return nil
local function bar()
  if some_condition then
    -- easier than writing "foo()\nreturn"
    return foo() -- error! returns `boolean`
  end

  -- rest of function
end
```

I also managed to piece together the proper data types for the animations, so I documented those.