### PR TITLE
feat: specify `icons` per buffer activity/state

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ files you can even type the letter ahead from memory.
 require('lazy').setup {
   {'romgrk/barbar.nvim',
     dependencies = 'nvim-tree/nvim-web-devicons',
+    opts = {
+      -- lazy.nvim can automatically call setup for you. just put your options here:
+      -- insert_at_start = true,
+      -- animation = true,
+      -- …etc
+    },
     version = '^1.0.0', -- optional: only update when a new 1.x version is released
   },
 }
@@ -234,22 +240,10 @@ let bufferline.auto_hide = v:false
 " Enable/disable current/total tabpages indicator (top right corner)
 let bufferline.tabpages = v:true
 
-" Enable/disable close button
-let bufferline.closable = v:true
-
 " Enables/disable clickable tabs
 "  - left-click: go to buffer
 "  - middle-click: delete buffer
 let bufferline.clickable = v:true
-
-" Enables / disables diagnostic symbols
-" ERROR / WARN / INFO / HINT
-let bufferline.diagnostics = [
-  \ {'enabled': v:true, 'icon': 'ﬀ'},
-  \ {'enabled': v:false},
-  \ {'enabled': v:false},
-  \ {'enabled': v:true},
-\]
 
 " Excludes buffers from the tabline
 let bufferline.exclude_ft = ['javascript']
@@ -271,23 +265,49 @@ let bufferline.highlight_inactive_file_icons = v:false
 " Enable highlighting visible buffers
 let bufferline.highlight_visible = v:true
 
-" Enable/disable icons
-" if set to 'buffer_number', will show buffer number in the tabline
-" if set to 'numbers', will show buffer index in the tabline
-" if set to 'both', will show buffer index and icons in the tabline
-" if set to 'buffer_number_with_icon', will show buffer number and icons in the tabline
-let bufferline.icons = v:true
+" Configure the base icons on the bufferline.
+let bufferline.icons = {
+  \'buffer_index': v:false,
+  \'buffer_number': v:false,
+  \'button': '',
+  \'filetype': {'enabled': v:true},
+  \'separator': {'left': '▎', 'right': ''},
+\}
 
-" Sets the icon's highlight group.
-" If false, will use nvim-web-devicons colors
-let bufferline.icon_custom_colors = v:false
+" Enables / disables diagnostic symbols
+" ERROR / WARN / INFO / HINT
+let bufferline.icons = v:lua.vim.tbl_deep_extend('force', bufferline.icons, {
+  \'diagnostics': [
+    \{'enabled': v:true, 'icon': 'ﬀ'},
+    \{'enabled': v:false},
+    \{'enabled': v:false},
+    \{'enabled': v:true}
+  \],
+\})
 
-" Configure icons on the bufferline.
-let bufferline.icon_separator_active = '▎'
-let bufferline.icon_separator_inactive = '▎'
-let bufferline.icon_close_tab = ''
-let bufferline.icon_close_tab_modified = '●'
-let bufferline.icon_pinned = '車'
+" If v:true, will use Buffer<Alternate|Current|Inactive|Visible>Icon
+" If v:false, will use nvim-web-devicons colors
+let bufferline.icons = v:lua.vim.tbl_deep_extend('force', bufferline.icons, {
+  \'filetype': {'custom_colors': v:false},
+\})
+
+" Configure the icons on the bufferline when modified or pinned.
+" Supports all the base icon options.
+" If v:true, will use Buffer<Alternate|Current|Inactive|Visible>Icon
+" If v:false, will use nvim-web-devicons colors
+let bufferline.icons = v:lua.vim.tbl_deep_extend('force', bufferline.icons, {
+  \'modified': {'button': '●'},
+  \'pinned': {'button': '車'},
+\})
+
+" Configure the icons on the bufferline based on the visibility of a buffer.
+" Supports all the base icon options, plus `modified` and `pinned`.
+let bufferline.icons = v:lua.vim.tbl_deep_extend('force', bufferline.icons, {
+  \'alternate': {'filetype': {'enabled': v:false}},
+  \'current': {'buffer_index': v:true},
+  \'inactive': {'button': '×'},
+  \'visible': {'modified': {'buffer_number': v:false}},
+\})
 
 " If true, new buffers will be inserted at the start/end of the list.
 " Default is to insert after current buffer.
@@ -334,28 +354,10 @@ require'bufferline'.setup {
   -- Enable/disable current/total tabpages indicator (top right corner)
   tabpages = true,
 
-  -- Enable/disable close button
-  closable = true,
-
   -- Enables/disable clickable tabs
   --  - left-click: go to buffer
   --  - middle-click: delete buffer
   clickable = true,
-
-  -- Enables / disables diagnostic symbols
-  diagnostics = {
-    -- you can use a list
-    {enabled = true, icon = 'ﬀ'}, -- ERROR
-    {enabled = false}, -- WARN
-    {enabled = false}, -- INFO
-    {enabled = true},  -- HINT
-
-    -- OR `vim.diagnostic.severity`
-    [vim.diagnostic.severity.ERROR] = {enabled = true, icon = 'ﬀ'},
-    [vim.diagnostic.severity.WARN] = {enabled = false},
-    [vim.diagnostic.severity.INFO] = {enabled = false},
-    [vim.diagnostic.severity.HINT] = {enabled = true},
-  },
 
   -- Excludes buffers from the tabline
   exclude_ft = {'javascript'},
@@ -377,23 +379,40 @@ require'bufferline'.setup {
   -- Enable highlighting visible buffers
   highlight_visible = true,
 
-  -- Enable/disable icons
-  -- if set to 'numbers', will show buffer index in the tabline
-  -- if set to 'both', will show buffer index and icons in the tabline
-  icons = true,
+  icons = {
+    -- Configure the base icons on the bufferline.
+    buffer_index = false,
+    buffer_number = false,
+    button = '',
+    -- Enables / disables diagnostic symbols
+    diagnostics = {
+      [vim.diagnostic.severity.ERROR] = {enabled = true, icon = 'ﬀ'},
+      [vim.diagnostic.severity.WARN] = {enabled = false},
+      [vim.diagnostic.severity.INFO] = {enabled = false},
+      [vim.diagnostic.severity.HINT] = {enabled = true},
+    },
+    filetype = {
+      -- Sets the icon's highlight group.
+      -- If false, will use nvim-web-devicons colors
+      custom_colors = false,
 
-  -- If set, the icon color will follow its corresponding buffer
-  -- highlight group. By default, the Buffer*Icon group is linked to the
-  -- Buffer* group (see Highlighting below). Otherwise, it will take its
-  -- default value as defined by devicons.
-  icon_custom_colors = false,
+      -- Requires `nvim-web-devicons` if `true`
+      enabled = true,
+    },
+    separator = {left = '▎', right = ''},
 
-  -- Configure icons on the bufferline.
-  icon_separator_active = '▎',
-  icon_separator_inactive = '▎',
-  icon_close_tab = '',
-  icon_close_tab_modified = '●',
-  icon_pinned = '車',
+    -- Configure the icons on the bufferline when modified or pinned.
+    -- Supports all the base icon options.
+    modified = {button = '●'},
+    pinned = {button = '車'},
+
+    -- Configure the icons on the bufferline based on the visibility of a buffer.
+    -- Supports all the base icon options, plus `modified` and `pinned`.
+    alternate = {filetype = {enabled = false}},
+    current = {buffer_index = true},
+    inactive = {button = '×'},
+    visible = {modified = {buffer_number = false}},
+  },
 
   -- If true, new buffers will be inserted at the start/end of the list.
   -- Default is to insert after current buffer.

--- a/autoload/bufferline/events.vim
+++ b/autoload/bufferline/events.vim
@@ -1,0 +1,19 @@
+function! bufferline#events#dict_changed(_dict, _key, changes) abort
+  silent! call dictwatcherdel(a:changes.old, '*', 'bufferline#events#on_option_changed')
+  call dictwatcheradd(a:changes.new, '*', 'bufferline#events#on_option_changed')
+  call bufferline#events#on_option_changed(a:changes.new, v:null, v:null)
+endfunction
+
+" TODO: get rid of this and use `v:lua` after raising minimum Neovim ver > 0.7
+function! bufferline#events#close_click_handler(minwid, _clicks, _btn, _modifiers) abort
+  call luaeval("require'bufferline.events'.close_click_handler(_A)", a:minwid)
+endfunction
+
+" TODO: get rid of this and use `v:lua` after raising minimum Neovim ver > 0.7
+function! bufferline#events#main_click_handler(minwid, _clicks, btn, _modifiers) abort
+  call luaeval("require'bufferline.events'.main_click_handler(_A[1], nil, _A[2])", [a:minwid, a:btn])
+endfunction
+
+function! bufferline#events#on_option_changed(dict, _1, _2) abort
+  call luaeval("require'bufferline.events'.on_option_changed(_A)", a:dict)
+endfunction

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -172,49 +172,120 @@ Here are the groups that you should define if you'd like to style Barbar.
   Enable/disable current/total tabpages indicator (top right corner).
 
                                                           *g:bufferline.icons*
-`g:bufferline.icons`  boolean, string  (default |v:true|)
+`g:bufferline.icons`  table
 
-Controls if icons are rendered on each tab.
+  Controls the icons rendered on each tab. The base options are:
 
-  - If `v:false`, show neither |devicons| nor buffer numbers.
-  - If `v:true`, show |devicons| for each buffer's |'filetype'|.
-  - If `"buffer_numbers"`, show the buffer number for current buffer.
-  - If `"numbers"`, show the buffer index for current buffer.
-  - If `"both"`, show the buffer index and |devicons|.
-  - If `"buffer_number_with_icon"`, show the buffer number for current buffer
-    and |devicons|.
+  buffer_index  (boolean) ~
+  - Default: |v:false|
+  - if `true`, show the index of the buffer with respect to the ordering of
+    the buffers in the tabline.
 
-                                             *g:bufferline.icon_custom_colors*
-`g:bufferline.icon_custom_colors`  boolean, string   (default |v:false|)
+  buffer_number  (boolean) ~
+  - Default: |v:false|
+  - If `true`, show the `bufnr` for the associated buffer.
 
-  Sets the icon's highlight group. If false, will use |devicons|
-  colors. (see |barbar-highlights|)
+  button  (false|string) ~
+  - Default: `''`
+  - The button which is clicked to close / save a buffer, or indicate that it
+    is pinned. Use `false` to disable it.
 
-                                          *g:bufferline.icon_separator_active*
-`g:bufferline.icon_separator_active`  string  (default '▎')
+  diagnostics (table<DiagnosticSeverity, table>) ~
+  - Default: >
+    {
+       [vim.diagnostic.severity.ERROR] = {enabled = false, icon = 'Ⓧ '},
+       [vim.diagnostic.severity.HINT] = {enabled = false, icon = '💡'},
+       [vim.diagnostic.severity.INFO] = {enabled = false, icon = 'ⓘ '},
+       [vim.diagnostic.severity.WARN] = {enabled = false, icon = '⚠️ '},
+    }
+< - Enables or disables showing diagnostics in the bufferline. The options
+    are:
+    - `enabled`, whether this diagnostics of this severity are shown in the
+      bufferline.
+    - `icon`, which controls what icon accompanies the number of diagnostics.
 
-  The separator for active and visible buffers.
 
-                                        *g:bufferline.icon_separator_inactive*
-`g:bufferline.icon_separator_inactive`  string  (default '▎')
+  filetype.custom_colors  (boolean) ~
+  - Default: |v:false|
+  - If present, this color will be used for ALL filetype icons
 
-  The separator for inactive buffers and the `BufferTabpageFill`.
+  filetype.enabled  (boolean) ~
+  - Default: |v:true|
+  - Filetype `true`, show the `devicons` for the associated buffer's `filetype`.
 
-                                                 *g:bufferline.icon_close_tab*
-`g:bufferline.icon_close_tab`  string  (default '')
+  separator  (table) ~
+  - Default: `{'left': '▎', 'right': ''}`
+  - The left-hand separator between buffers in the tabline.
 
-  The button used to close the tab.
+  Example: >
+    " Show the file icon, a left separator, and ERROR/WARN diagnostics
+    let bufferline.icons = {
+      \'buffer_index': v:false,
+      \'buffer_number': v:false,
+      \'button': '',
+      \'diagnostics': [{'enabled': v:true}, {'enabled': v:true}],
+      \'filetype': {'enabled': v:true},
+      \'separator': {'left': '▎'},
+    \}
+<
 
-                                        *g:bufferline.icon_close_tab_modified*
-`g:bufferline.icon_close_tab_modified`  string  (default '●')
+  You can also customize icons of 'modified' and pinned buffers:
 
-  The button used to close the tab when it has been modified since
-  last save.
+  modified (table) ~
+  - Default: `{'button': '●'}`
+  - The icons which should be used for a 'modified' buffer.
+  - Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
+    etc)
 
-                                                    *g:bufferline.icon_pinned*
-`g:bufferline.icon_pinned`                            string (default '車')
+  pinned (table) ~
+  - Default: `{'button': ''}`
+  - The icons which should be used for a pinned buffer.
+  - Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
+    etc)
 
-  The icon used to indicate that a buffer is pinned.
+  Example: >
+    " Change the button only when the buffer is modified or pinned
+    let bufferline.icons = {
+        \'modified': {'button': '●'},
+        \'pinned': {'button': '車'},
+    \}
+<
+
+  Lastly, you can customize icons based on the visibility of a buffer:
+
+  alternate (table) ~
+  - The icons which should be used for the |alternate-file|.
+  - Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
+    etc) as well as `modified` and `pinned`.
+
+  current (table) ~
+  - The icons which should be used for current buffer.
+  - Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
+    etc) as well as `modified` and `pinned`.
+
+  inactive (table) ~
+  - Default: `{'separator': {'left': '▎', 'right': ''}}`
+  - The icons which should be used for |hidden-buffer|s and |inactive-buffer|s.
+  - Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
+    etc) as well as `modified` and `pinned`.
+
+  visible (table) ~
+  - The icons which should be used for |active-buffer|s.
+  - Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
+    etc) as well as `modified` and `pinned`.
+
+  Example: >
+    " Enable file icons for alternate buffers.
+    " Enable buffer indices for current buffers.
+    " Override the button for inactive buffers.
+    " Disable buffer numbers for visible, modified buffers.
+    let bufferline.icons = {
+      \'alternate': {'filetype': {'enabled': v:false}},
+      \'current': {'buffer_index': v:true},
+      \'inactive': {'button': '×'},
+      \'visible': {'modified': {'buffer_number': v:false}},
+    \}
+<
 
                                                 *g:bufferline.insert_at_start*
 `g:bufferline.insert_at_start` boolean  (default |v:false|)
@@ -228,11 +299,6 @@ Controls if icons are rendered on each tab.
 
   If true, new buffers appear at the end of the list. Default is to
   open after the current buffer.
-
-                                                       *g:bufferline.closable*
-`g:bufferline.closable`  boolean  (default |v:true|)
-
-  Controls if close buttons are shown.
 
                                                *g:bufferline.semantic_letters*
 `g:bufferline.semantic_letters`  boolean  (default |v:true|)
@@ -328,27 +394,6 @@ Controls if icons are rendered on each tab.
     let g:bufferline.hide = {'current': v:false, 'inactive': v:true}
 <
 
-                                                    *g:bufferline.diagnostics*
-`g:bufferline.diagnostics`  list
-
-  Default: >
-  {
-    [vim.diagnostic.severity.ERROR] = {enabled = false, icon = 'Ⓧ '},
-    [vim.diagnostic.severity.HINT] = {enabled = false, icon = '💡'},
-    [vim.diagnostic.severity.INFO] = {enabled = false, icon = 'ⓘ '},
-    [vim.diagnostic.severity.WARN] = {enabled = false, icon = '⚠️ '},
-  }
-<
-
-  Enables or disables showing diagnostics in the bufferline. You can use
-  |vim.diagnostic.severity| or a list (e.g.
-  `{{enabled = true}, {enabled = true},` …`}`) in the order of
-  ERROR/WARN/INFO/HINT.
-
-  - `enabled`, whether this diagnostics of this severity are shown in the
-    bufferline.
-  - `icon`, which controls what icon accompanies the number of diagnostics.
-
                                             *g:bufferline.highlight_alternate*
 `g:bufferline.highlight_alternate`  boolean  (default |v:false|)
 
@@ -385,23 +430,40 @@ Controls if icons are rendered on each tab.
 ==============================================================================
 5. Integrations                                          *barbar-integrations*
 
-with filetree plugins
+------------------------------------------------------------------------------
+FILETREE PLUGINS
 
-bind open and close commands to (e.g. nvim-tree):
+To ensure tabs begin with the shown buffer you can set an offset for the
+tabline. Add this |autocmd| to your configuration: >
+    vim.api.nvim_create_autocmd('FileType', {
+      callback = function(tbl)
+        local set_offset = require('bufferline.api').set_offset
 
->
-    local tree = {}
-    tree.open = function ()
-       require'bufferline.api'.set_offset(31, 'FileTree')
-       require'nvim-tree'.find_file(true)
-    end
+        local bufwinid
+        local last_width
+        local autocmd = vim.api.nvim_create_autocmd('WinScrolled', {
+          callback = function()
+            bufwinid = bufwinid or vim.fn.bufwinid(tbl.buf)
 
-    tree.close = function ()
-       require'bufferline.api'.set_offset(0)
-       require'nvim-tree'.close()
-    end
+            local width = vim.api.nvim_win_get_width(bufwinid)
+            if width ~= last_width then
+              set_offset(width, 'FileTree')
+              last_width = width
+            end
+          end,
+        })
 
-    return tree
+        vim.api.nvim_create_autocmd('BufWipeout', {
+          buffer = tbl.buf,
+          callback = function()
+            vim.api.nvim_del_autocmd(autocmd)
+            set_offset(0)
+          end,
+          once = true,
+        })
+      end,
+      pattern = 'NvimTree', -- or any other filetree's `ft`
+    })
 <
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -15,6 +15,7 @@ local notify = require'bufferline.utils'.notify
 local options = require'bufferline.options'
 local render = require'bufferline.render'
 local state = require'bufferline.state'
+local utils = require'bufferline.utils'
 
 -------------------------------
 -- Section: `bufferline` module
@@ -51,8 +52,12 @@ function bufferline.setup(user_config)
     function(tbl)
       local index = tonumber(tbl.args)
       if not index then
-        return notify('Invalid argument to `:BufferGoto`', vim.log.levels.ERROR)
+        return notify(
+          'Invalid argument to ' .. utils.markdown_inline_code':BufferGoto',
+          vim.log.levels.ERROR
+        )
       end
+
       api.goto_buffer(index)
     end,
     {
@@ -81,7 +86,7 @@ function bufferline.setup(user_config)
   create_user_command(
     'BufferMove',
     function(tbl) command('BufferMovePrevious ' .. tbl.count) end,
-    {count = true, desc = 'Synonym for `:BufferMovePrevious`'}
+    {count = true, desc = 'Synonym for ' .. utils.markdown_inline_code':BufferMovePrevious'}
   )
 
   create_user_command(

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -85,7 +85,9 @@ function bufferline.setup(user_config)
 
   create_user_command(
     'BufferMove',
-    function(tbl) command('BufferMovePrevious ' .. tbl.count) end,
+    vim.api.nvim_cmd and
+      function(tbl) vim.cmd.BufferMovePrevious {count = tbl.count} end or
+      function(tbl) command('BufferMovePrevious ' .. tbl.count) end,
     {count = true, desc = 'Synonym for ' .. utils.markdown_inline_code':BufferMovePrevious'}
   )
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -200,7 +200,8 @@ function bufferline.setup(user_config)
 
   -- Setup barbar
   events.enable()
-  vim.g.bufferline = user_config
+  events.on_option_changed(user_config)
+  vim.api.nvim_set_var('bufferline', user_config)
 
   -- Show the tabline
   set_option('showtabline', 2)

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -39,13 +39,11 @@ local function pick_buffer_wrap(fn)
 
   state.is_picking_buffer = true
   render.update()
-  command('redrawtabline')
 
   fn()
 
   state.is_picking_buffer = false
   render.update()
-  command('redrawtabline')
 end
 
 --- Shows an error that `bufnr` was not among the `state.buffers`
@@ -438,7 +436,6 @@ function api.pick_buffer_delete()
       end
 
       render.update()
-      command('redrawtabline')
     end
   end)
 end

--- a/lua/bufferline/api.lua
+++ b/lua/bufferline/api.lua
@@ -96,8 +96,9 @@ end
 --- Close all open buffers, except those in visible windows.
 --- @return nil
 function api.close_all_but_visible()
+  local visible = Buffer.activities.Visible
   for _, buffer_number in ipairs(state.buffers) do
-    if Buffer.get_activity(buffer_number) < 3 then
+    if Buffer.get_activity(buffer_number) < visible then
       bbye.bdelete(false, buffer_number)
     end
   end

--- a/lua/bufferline/bbye.lua
+++ b/lua/bufferline/bbye.lua
@@ -75,7 +75,7 @@ local function get_focus_on_close(closing_number)
   if #state_bufnrs < 1 then -- all of the buffers are excluded or unlisted
     local open_bufnrs = list_bufs()
     if focus_on_close == 'right' then
-      open_bufnrs = utils.reverse(open_bufnrs)
+      open_bufnrs = utils.list_reverse(open_bufnrs)
     end
 
     for _, nr in ipairs(open_bufnrs) do
@@ -88,7 +88,7 @@ local function get_focus_on_close(closing_number)
   end
 
   if focus_on_close == 'right' then
-    state_bufnrs = utils.reverse(state.buffers)
+    state_bufnrs = utils.list_reverse(state.buffers)
   end
 
   local index = utils.index_of(state_bufnrs, closing_number)
@@ -187,7 +187,7 @@ function bbye.delete(action, force, buffer, mods)
 
   -- For cases where adding buffers causes new windows to appear or hiding some
   -- causes windows to disappear and thereby decrement, loop backwards.
-  for _, window_number in ipairs(utils.reverse(list_wins())) do
+  for _, window_number in ipairs(utils.list_reverse(list_wins())) do
     if win_get_buf(window_number) == buffer_number then
       set_current_win(window_number)
 

--- a/lua/bufferline/bbye.lua
+++ b/lua/bufferline/bbye.lua
@@ -65,6 +65,14 @@ local cmd = vim.api.nvim_cmd and
     command((mods or '') .. " " .. action .. (force and '!' or '') .. " " .. buffer_number)
   end
 
+local enew = vim.api.nvim_cmd and
+  --- The `:enew` command
+  --- @param force boolean
+  function(force) vim.cmd.enew {bang = force} end or
+  --- The `:enew` command
+  --- @param force boolean
+  function(force) command("enew" .. (force and '!' or '')) end
+
 --- @param closing_number integer
 --- @return nil|integer bufnr of the buffer to focus
 local function get_focus_on_close(closing_number)
@@ -121,7 +129,7 @@ local empty_buffer = nil --- @type nil|integer
 --- @param force boolean if `true`, forcefully create the new buffer
 --- @return nil
 local function new(force)
-  command("enew" .. (force and '!' or ''))
+  enew(force)
 
   empty_buffer = get_current_buf()
   vim.b.empty_buffer = true

--- a/lua/bufferline/bbye.lua
+++ b/lua/bufferline/bbye.lua
@@ -30,7 +30,6 @@ local bufnr = vim.fn.bufnr --- @type function
 local command = vim.api.nvim_command --- @type function
 local create_augroup = vim.api.nvim_create_augroup --- @type function
 local create_autocmd = vim.api.nvim_create_autocmd --- @type function
-local exec_autocmds = vim.api.nvim_exec_autocmds --- @type function
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local get_current_win = vim.api.nvim_get_current_win --- @type function
 local get_option = vim.api.nvim_get_option --- @type function
@@ -233,8 +232,6 @@ function bbye.delete(action, force, buffer, mods)
       end
     end
   end
-
-  exec_autocmds('BufWinEnter', {})
 end
 
 --- 'bdelete' a buffer

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -30,6 +30,10 @@ local utils = require'bufferline.utils'
 
 --- @alias bufferline.buffer.activity.name 'Inactive'|'Alternate'|'Visible'|'Current'
 
+--- A bidirectional map of activities to activity names
+--- @type {[bufferline.buffer.activity]: bufferline.buffer.activity.name, [bufferline.buffer.activity.name]: bufferline.buffer.activity}
+local activities = vim.tbl_add_reverse_lookup {'Inactive', 'Alternate', 'Visible', 'Current'}
+
 --- The character used to delimit paths (e.g. `/` or `\`).
 local separator = package.config:sub(1, 1)
 
@@ -48,14 +52,14 @@ end
 --- @return bufferline.buffer.activity # whether `bufnr` is inactive, the alternate file, visible, or currently selected (in that order).
 local function get_activity(buffer_number)
   if get_current_buf() == buffer_number then
-    return 4
+    return activities.Current
   elseif options.highlight_alternate() and bufnr('#') == buffer_number then
-    return 2
+    return activities.Alternate
   elseif options.highlight_visible() and bufwinnr(buffer_number) ~= -1 then
-    return 3
+    return activities.Visible
   end
 
-  return 1
+  return activities.Inactive
 end
 
 --- @param buffer_number integer
@@ -72,6 +76,8 @@ end
 
 --- @class bufferline.buffer
 local buffer = {
+  activities = activities,
+
   count_diagnostics = count_diagnostics,
 
   --- For each severity in `diagnostics`: if it is enabled, and there are diagnostics associated with it in the `buffer_number` provided, call `f`.
@@ -165,9 +171,9 @@ local buffer = {
     if hide.alternate or hide.current or hide.inactive or hide.visible then
       local shown = {}
 
-      hide = {hide.inactive, hide.visible, hide.alternate, hide.current}
       for _, buffer_number in ipairs(bufnrs) do
-        if not hide[get_activity(buffer_number)] then
+        local activity = activities[get_activity(buffer_number)]
+        if not hide[activity:lower()] then
           table_insert(shown, buffer_number)
         end
       end

--- a/lua/bufferline/buffer.lua
+++ b/lua/bufferline/buffer.lua
@@ -76,14 +76,17 @@ local buffer = {
 
   --- For each severity in `diagnostics`: if it is enabled, and there are diagnostics associated with it in the `buffer_number` provided, call `f`.
   --- @param buffer_number integer the buffer number to count diagnostics in
-  --- @param diagnostics bufferline.options.diagnostics the user configuration for diagnostics
-  --- @param f fun(count: integer, diagnostic: bufferline.options.diagnostics.severity, severity: integer) the function to run when diagnostics of a specific severity are enabled and present in the `buffer_number`
+  --- @param diagnostics bufferline.options.icons.diagnostics the user configuration for diagnostics
+  --- @param f fun(count: integer, diagnostic: bufferline.options.icons.diagnostics.severity, severity: integer) the function to run when diagnostics of a specific severity are enabled and present in the `buffer_number`
   --- @return nil
   for_each_counted_enabled_diagnostic = function(buffer_number, diagnostics, f)
     local count
     for severity, severity_config in ipairs(diagnostics) do
       if severity_config.enabled then
-        count = count or count_diagnostics(buffer_number)
+        if count == nil then
+          count = count_diagnostics(buffer_number)
+        end
+
         if count[severity] > 0 then
           f(count[severity], severity_config, severity)
         end

--- a/lua/bufferline/events.lua
+++ b/lua/bufferline/events.lua
@@ -91,8 +91,11 @@ function events.enable()
   })
 
   create_autocmd({'BufDelete', 'BufWipeout'}, {
-    callback = function(tbl) JumpMode.unassign_letter_for(tbl.buf) end,
-    group = augroup_misc,
+    callback = vim.schedule_wrap(function(tbl)
+      JumpMode.unassign_letter_for(tbl.buf)
+      render.update()
+    end),
+    group = augroup_render,
   })
 
   create_autocmd('ColorScheme', {callback = highlight.setup, group = augroup_misc})

--- a/lua/bufferline/events.lua
+++ b/lua/bufferline/events.lua
@@ -98,7 +98,13 @@ function events.enable()
     group = augroup_render,
   })
 
-  create_autocmd('ColorScheme', {callback = highlight.setup, group = augroup_misc})
+  create_autocmd('ColorScheme', {
+    callback = function()
+      utils.hl.reset_cache()
+      highlight.setup()
+    end,
+    group = augroup_misc,
+  })
 
   create_autocmd('BufModifiedSet', {
     callback = function(tbl)

--- a/lua/bufferline/events.lua
+++ b/lua/bufferline/events.lua
@@ -1,0 +1,295 @@
+local table_insert = table.insert
+
+local buf_call = vim.api.nvim_buf_call --- @type function
+local buf_get_name = vim.api.nvim_buf_get_name --- @type function
+local buf_get_option = vim.api.nvim_buf_get_option --- @type function
+local buf_set_var = vim.api.nvim_buf_set_var --- @type function
+local command = vim.api.nvim_command --- @type function
+local create_augroup = vim.api.nvim_create_augroup --- @type function
+local create_autocmd = vim.api.nvim_create_autocmd --- @type function
+local defer_fn = vim.defer_fn
+local exec_autocmds = vim.api.nvim_exec_autocmds --- @type function
+local list_tabpages = vim.api.nvim_list_tabpages --- @type function
+local schedule = vim.schedule --- @type function
+local schedule_wrap = vim.schedule_wrap
+local set_current_buf = vim.api.nvim_set_current_buf --- @type function
+local tabpage_list_wins = vim.api.nvim_tabpage_list_wins --- @type function
+
+local bbye = require'bufferline.bbye'
+local highlight = require'bufferline.highlight'
+local JumpMode = require'bufferline.jump_mode'
+local options = require'bufferline.options'
+local render = require'bufferline.render'
+local state = require'bufferline.state'
+local utils = require'bufferline.utils'
+
+--- Whether barbar is currently set up to render.
+local enabled = false
+
+--- Stop watching `g:bufferline`
+--- WARN: must be `vim.schedule`d
+--- @return nil
+local function dictwatcherdel()
+  vim.cmd [[
+    silent! call dictwatcherdel(g:, 'bufferline', 'BufferlineDictChanged')
+    silent! call dictwatcherdel(g:bufferline, '*', 'BufferlineOnOptionChanged')
+  ]]
+end
+
+--- @class bufferline.events
+local events = {}
+
+--- Create and reset autocommand groups associated with this plugin.
+--- @param clear? boolean
+--- @return integer misc, integer render
+function events.augroups(clear)
+  if clear == nil then
+    clear = true
+  end
+
+  return create_augroup('bufferline_misc', {clear = clear}),
+    create_augroup('bufferline_render', {clear = clear})
+end
+
+--- What to do when clicking a buffer close button
+--- NOTE: must be global -_-
+--- @param buffer integer
+--- @return nil
+function events.close_click_handler(buffer)
+  if buf_get_option(buffer, 'modified') then
+    buf_call(buffer, function() command('w') end)
+    exec_autocmds('BufModifiedSet', {buffer = buffer})
+  else
+    bbye.bdelete(false, buffer)
+  end
+end
+
+--- Stop listening and responding to various editor events
+--- @return nil
+events.disable = schedule_wrap(function()
+  events.augroups() -- clear the autocommands
+
+  -- clean up the global namespace
+  dictwatcherdel()
+  vim.cmd [[
+    delfunction! BufferlineDictChanged
+    delfunction! BufferlineOnOptionChanged
+  ]]
+
+  render.set_tabline(nil) -- clear the tabline
+  enabled = false -- mark as disabled
+end)
+
+--- Start listening and responding to various editor events
+--- @return nil
+function events.enable()
+  local augroup_misc, augroup_render = events.augroups()
+
+  create_autocmd({'BufNewFile', 'BufReadPost'}, {
+    callback = function(tbl) JumpMode.assign_next_letter(tbl.buf) end,
+    group = augroup_misc,
+  })
+
+  create_autocmd({'BufDelete', 'BufWipeout'}, {
+    callback = function(tbl) JumpMode.unassign_letter_for(tbl.buf) end,
+    group = augroup_misc,
+  })
+
+  create_autocmd('ColorScheme', {callback = highlight.setup, group = augroup_misc})
+
+  create_autocmd('BufModifiedSet', {
+    callback = function(tbl)
+      local is_modified = buf_get_option(tbl.buf, 'modified')
+      if is_modified ~= vim.b[tbl.buf].checked then
+        buf_set_var(tbl.buf, 'checked', is_modified)
+        render.update()
+      end
+    end,
+    group = augroup_render,
+  })
+
+  create_autocmd({'BufEnter', 'BufNew'}, {
+    callback = function() render.update(true) end,
+    group = augroup_render,
+  })
+
+  create_autocmd(
+    {
+      'BufEnter', 'BufWinEnter', 'BufWinLeave', 'BufWritePost',
+      'DiagnosticChanged',
+      'TabEnter',
+      'VimResized',
+      'WinEnter', 'WinLeave',
+    },
+    {
+      callback = function() render.update() end,
+      group = augroup_render,
+    }
+  )
+
+  create_autocmd('OptionSet', {
+    callback = function() render.update() end,
+    group = augroup_render,
+    pattern = 'buflisted',
+  })
+
+  create_autocmd('SessionLoadPost', {
+    -- TODO: I'm not sure if this whole thing can just be thrown in a `schedule_wrap`
+    --       in order to remove the inner `defer_fn` and `schedule` calls
+    callback = function()
+      if state.loading_session then
+        return
+      end
+
+      local restore_cmd = vim.g.Bufferline__session_restore
+      if restore_cmd then command(restore_cmd) end
+
+      vim.defer_fn(function() state.loading_session = false end, 100)
+      schedule(function() render.update(true) end)
+    end,
+    group = augroup_render,
+  })
+
+  create_autocmd('TermOpen', {
+    callback = function() defer_fn(function() render.update(true) end, 500) end,
+    group = augroup_render,
+  })
+
+  create_autocmd('User', {
+    callback = function()
+      -- We're allowed to use relative paths for buffers iff there are no tabpages
+      -- or windows with a local directory (:tcd and :lcd)
+      local use_relative_file_paths = true
+
+      -- PERF: I didn't import `haslocaldir` since it is only used here (just before calling `:mksession` and exiting vim)
+      local haslocaldir = vim.fn.haslocaldir --- @type function
+
+      for tabnr, tabpage in ipairs(list_tabpages()) do
+        if not use_relative_file_paths or haslocaldir(-1, tabnr) == 1 then
+          use_relative_file_paths = false
+          break
+        end
+
+        for _, win in ipairs(tabpage_list_wins(tabpage)) do
+          if haslocaldir(win, tabnr) == 1 then
+            use_relative_file_paths = false
+            break
+          end
+        end
+      end
+
+      local buffers = {}
+      for _, bufnr in ipairs(state.buffers) do
+        local name = buf_get_name(bufnr)
+        if use_relative_file_paths then
+          name = utils.relative(name)
+        end
+
+        -- escape quotes
+        table_insert(buffers, {name = name, pinned =  state.get_buffer_data(bufnr).pinned})
+      end
+
+      vim.g.Bufferline__session_restore = "lua require'bufferline.state'.restore_buffers " ..
+        vim.inspect(buffers, {newline = ' ', indent = ''})
+    end,
+    group = augroup_misc,
+    pattern = 'SessionSavePre',
+  })
+
+  create_autocmd('WinClosed', {
+    callback = schedule_wrap(render.update),
+    group = augroup_render,
+  })
+
+  vim.schedule(function()
+    dictwatcherdel()
+    vim.cmd [[
+      " Must be global -_-
+      function! BufferlineDictChanged(dict, key, changes) abort
+        silent! call dictwatcherdel(a:changes.old, '*', 'BufferlineOnOptionChanged')
+        call dictwatcheradd(a:changes.new, '*', 'BufferlineOnOptionChanged')
+        call BufferlineOnOptionChanged(a:changes.new, v:null, v:null)
+      endfunction
+
+      " TODO: get rid of this and use `v:lua` after raising minimum Neovim ver > 0.7
+      " Must be global -_-
+      function! BufferlineCloseClickHandler(minwid, clicks, btn, modifiers) abort
+        call luaeval("require'bufferline.events'.close_click_handler(_A)", a:minwid)
+      endfunction
+
+      " TODO: get rid of this and use `v:lua` after raising minimum Neovim ver > 0.7
+      " Must be global -_-
+      function! BufferlineMainClickHandler(minwid, clicks, btn, modifiers) abort
+        call luaeval("require'bufferline.events'.main_click_handler(_A[1], nil, _A[2])", [a:minwid, a:btn])
+      endfunction
+
+      " Must be global -_-
+      function! BufferlineOnOptionChanged(dict, _1, _2) abort
+        call luaeval("require'bufferline.events'.on_option_changed(_A)", a:dict)
+      endfunction
+
+      call dictwatcheradd(g:, 'bufferline', 'BufferlineDictChanged')
+      call dictwatcheradd(g:bufferline, '*', 'BufferlineOnOptionChanged')
+    ]]
+  end)
+
+  render.update()
+  enabled = true
+end
+
+--- What to do when clicking a buffer label
+--- NOTE: must be global -_-
+--- @param bufnr integer the buffer nummber
+--- @param btn string
+--- @return nil
+function events.main_click_handler(bufnr, _, btn, _)
+  if bufnr == 0 then
+    return
+  end
+
+  -- NOTE: in Vimscript this was not `==`, it was a regex compare `=~`
+  if btn == 'm' then
+    bbye.bdelete(false, bufnr)
+  else
+    render.set_current_win_listed_buffer()
+    set_current_buf(bufnr)
+  end
+end
+
+--- What to do when the user configuration changes
+--- @param user_config table
+--- @return nil
+function events.on_option_changed(user_config)
+  options.setup(user_config) -- NOTE: must be first `setup` called here
+  highlight.setup()
+  JumpMode.set_letters(options.letters())
+
+  -- Don't jump-start barbar if it is disabled
+  if enabled then
+    render.update()
+  end
+end
+
+-- HACK: This is the only way to implement `dictwatcheradd` for global
+--       variables in Lua. The devs said in neovim/neovim#18393 and
+--       neovim/neovim#21469 that this is intended, no matter how hacky
+--       it is.
+do
+  --- The `vim.g` functionality
+  local vim_g_metatable = getmetatable(vim.g)
+
+  --- The `vim.g.foo = bar` function
+  local vim_g_metatable__newindex = vim_g_metatable.__newindex
+
+  --- @param tbl table
+  --- @param k string
+  --- @param v any
+  function vim_g_metatable.__newindex(tbl, k, v)
+    vim_g_metatable__newindex(tbl, k, v)
+    if k == 'bufferline' then
+      events.on_option_changed(v)
+    end
+  end
+end
+
+return events

--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -10,6 +10,7 @@ hl.set_default_link('BufferAlternateERROR', 'BufferDefaultAlternateERROR')
 hl.set_default_link('BufferAlternateHINT', 'BufferDefaultAlternateHINT')
 hl.set_default_link('BufferAlternateIcon', 'BufferDefaultAlternateIcon')
 hl.set_default_link('BufferAlternateIndex', 'BufferDefaultAlternateIndex')
+hl.set_default_link('BufferAlternateNumber', 'BufferDefaultAlternateNumber')
 hl.set_default_link('BufferAlternateINFO', 'BufferDefaultAlternateINFO')
 hl.set_default_link('BufferAlternateMod', 'BufferDefaultAlternateMod')
 hl.set_default_link('BufferAlternateSign', 'BufferDefaultAlternateSign')
@@ -21,6 +22,7 @@ hl.set_default_link('BufferCurrentERROR', 'BufferDefaultCurrentERROR')
 hl.set_default_link('BufferCurrentHINT', 'BufferDefaultCurrentHINT')
 hl.set_default_link('BufferCurrentIcon', 'BufferDefaultCurrentIcon')
 hl.set_default_link('BufferCurrentIndex', 'BufferDefaultCurrentIndex')
+hl.set_default_link('BufferCurrentNumber', 'BufferDefaultCurrentNumber')
 hl.set_default_link('BufferCurrentINFO', 'BufferDefaultCurrentINFO')
 hl.set_default_link('BufferCurrentMod', 'BufferDefaultCurrentMod')
 hl.set_default_link('BufferCurrentSign', 'BufferDefaultCurrentSign')
@@ -32,6 +34,7 @@ hl.set_default_link('BufferInactiveERROR', 'BufferDefaultInactiveERROR')
 hl.set_default_link('BufferInactiveHINT', 'BufferDefaultInactiveHINT')
 hl.set_default_link('BufferInactiveIcon', 'BufferDefaultInactiveIcon')
 hl.set_default_link('BufferInactiveIndex', 'BufferDefaultInactiveIndex')
+hl.set_default_link('BufferInactiveNumber', 'BufferDefaultInactiveNumber')
 hl.set_default_link('BufferInactiveINFO', 'BufferDefaultInactiveINFO')
 hl.set_default_link('BufferInactiveMod', 'BufferDefaultInactiveMod')
 hl.set_default_link('BufferInactiveSign', 'BufferDefaultInactiveSign')
@@ -48,6 +51,7 @@ hl.set_default_link('BufferVisibleERROR', 'BufferDefaultVisibleERROR')
 hl.set_default_link('BufferVisibleHINT', 'BufferDefaultVisibleHINT')
 hl.set_default_link('BufferVisibleIcon', 'BufferDefaultVisibleIcon')
 hl.set_default_link('BufferVisibleIndex', 'BufferDefaultVisibleIndex')
+hl.set_default_link('BufferVisibleNumber', 'BufferDefaultVisibleNumber')
 hl.set_default_link('BufferVisibleINFO', 'BufferDefaultVisibleINFO')
 hl.set_default_link('BufferVisibleMod', 'BufferDefaultVisibleMod')
 hl.set_default_link('BufferVisibleSign', 'BufferDefaultVisibleSign')
@@ -56,10 +60,14 @@ hl.set_default_link('BufferVisibleWARN', 'BufferDefaultVisibleWARN')
 
 -- NOTE: these should move to `setup_defaults` if the definition stops being a link
 hl.set_default_link('BufferDefaultAlternateIcon', 'BufferAlternate')
+hl.set_default_link('BufferDefaultAlternateNumber', 'BufferAlternateIndex')
 hl.set_default_link('BufferDefaultCurrentIcon', 'BufferCurrent')
+hl.set_default_link('BufferDefaultCurrentNumber', 'BufferCurrentIndex')
 hl.set_default_link('BufferDefaultInactiveIcon', 'BufferInactive')
-hl.set_default_link('BufferDefaultVisibleIcon', 'BufferVisible')
+hl.set_default_link('BufferDefaultInactiveNumber', 'BufferInactiveIndex')
 hl.set_default_link('BufferDefaultOffset', 'BufferTabpageFill')
+hl.set_default_link('BufferDefaultVisibleIcon', 'BufferVisible')
+hl.set_default_link('BufferDefaultVisibleNumber', 'BufferVisibleIndex')
 
 --- @class bufferline.highlight
 local highlight = {
@@ -89,6 +97,7 @@ local highlight = {
     --     Inactive: invisible but not current buffer
     --        -Icon: filetype icon
     --       -Index: buffer index
+    --      -Number: buffer numebr
     --         -Mod: when modified
     --        -Sign: the separator between buffers
     --      -Target: letter in buffer-picking mode

--- a/lua/bufferline/highlight.lua
+++ b/lua/bufferline/highlight.lua
@@ -76,7 +76,7 @@ local highlight = {
   setup = function()
     local fg_current = hl.fg_or_default({'Normal'}, '#efefef', 255)
     local fg_inactive = hl.fg_or_default({'TabLineFill'}, '#888888', 102)
-    local fg_target = {gui = 'red'} --- @type barbar.utils.hl.group
+    local fg_target = {gui = 'red'} --- @type barbar.utils.hl.color
     fg_target.cterm = fg_target.gui
 
     local fg_error = hl.fg_or_default({'ErrorMsg'}, '#A80000', 124)
@@ -112,7 +112,7 @@ local highlight = {
       hl.set('BufferDefaultAlternateINFO',    bg_alternate, fg_info)
       hl.set('BufferDefaultAlternateMod',     bg_alternate, fg_modified)
       hl.set('BufferDefaultAlternateSign',    bg_alternate, fg_special)
-      hl.set('BufferDefaultAlternateTarget',  bg_alternate, fg_target, true)
+      hl.set('BufferDefaultAlternateTarget',  bg_alternate, fg_target, nil, {bold = true})
       hl.set('BufferDefaultAlternateWARN',    bg_alternate, fg_warn)
     end
 
@@ -123,7 +123,7 @@ local highlight = {
     hl.set('BufferDefaultCurrentINFO',    bg_current, fg_info)
     hl.set('BufferDefaultCurrentMod',     bg_current, fg_modified)
     hl.set('BufferDefaultCurrentSign',    bg_current, fg_special)
-    hl.set('BufferDefaultCurrentTarget',  bg_current, fg_target, true)
+    hl.set('BufferDefaultCurrentTarget',  bg_current, fg_target, nil, {bold = true})
     hl.set('BufferDefaultCurrentWARN',    bg_current, fg_warn)
 
     hl.set('BufferDefaultInactive',       bg_inactive, fg_inactive)
@@ -133,11 +133,11 @@ local highlight = {
     hl.set('BufferDefaultInactiveINFO',   bg_inactive, fg_info)
     hl.set('BufferDefaultInactiveMod',    bg_inactive, fg_modified)
     hl.set('BufferDefaultInactiveSign',   bg_inactive, fg_subtle)
-    hl.set('BufferDefaultInactiveTarget', bg_inactive, fg_target, true)
+    hl.set('BufferDefaultInactiveTarget', bg_inactive, fg_target, nil, {bold = true})
     hl.set('BufferDefaultInactiveWARN',   bg_inactive, fg_warn)
 
     hl.set('BufferDefaultTabpageFill',    bg_inactive, fg_inactive)
-    hl.set('BufferDefaultTabpages',       bg_inactive, fg_special, true)
+    hl.set('BufferDefaultTabpages',       bg_inactive, fg_special, nil, {bold = true})
 
     if options.highlight_visible() then
       local fg_visible = hl.fg_or_default({'TabLineSel'}, '#efefef', 255)
@@ -150,7 +150,7 @@ local highlight = {
       hl.set('BufferDefaultVisibleINFO',    bg_visible, fg_info)
       hl.set('BufferDefaultVisibleMod',     bg_visible, fg_modified)
       hl.set('BufferDefaultVisibleSign',    bg_visible, fg_visible)
-      hl.set('BufferDefaultVisibleTarget',  bg_visible, fg_target, true)
+      hl.set('BufferDefaultVisibleTarget',  bg_visible, fg_target, nil, {bold = true})
       hl.set('BufferDefaultVisibleWARN',    bg_visible, fg_warn)
     end
 

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -20,10 +20,13 @@ local ok, web = pcall(require, 'nvim-web-devicons')
 --- @param icon_hl string
 --- @return nil
 local function hl_buffer_icon(buffer_status, icon_hl)
+  local buffer_status_hl = {'Buffer' .. buffer_status}
   hl.set(
     icon_hl .. buffer_status,
-    hl.bg_or_default({'Buffer' .. buffer_status}, 'none'),
-    hl.fg_or_default({icon_hl}, 'none')
+    hl.bg_or_default(buffer_status_hl, 'none'),
+    hl.fg_or_default({icon_hl}, 'none'),
+    hl.sp_or_default(buffer_status_hl, 'none'),
+    hl.attributes(buffer_status_hl)
   )
 end
 

--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -52,7 +52,9 @@ local icons = {
     if ok == false then
       utils.notify(
         'barbar: bufferline.icons is set to v:true but "nvim-dev-icons" was not found.' ..
-          '\nbarbar: icons have been disabled. Set `bufferline.icons` to `false` or ' ..
+          '\nbarbar: icons have been disabled. Set ' ..
+          utils.markdown_inline_code'bufferline.icons' .. ' to ' ..
+          utils.markdown_inline_code'false' .. ' or ' ..
           'install "nvim-dev-icons" to disable this message.',
         vim.log.levels.WARN
       )

--- a/lua/bufferline/options.lua
+++ b/lua/bufferline/options.lua
@@ -1,39 +1,30 @@
+local table_concat = table.concat
+
 local ERROR = vim.diagnostic.severity.ERROR --- @type integer
 local HINT = vim.diagnostic.severity.HINT --- @type integer
 local INFO = vim.diagnostic.severity.INFO --- @type integer
 local tbl_deep_extend = vim.tbl_deep_extend
 local WARN = vim.diagnostic.severity.WARN --- @type integer
 
+local utils = require'bufferline.utils'
+
+--- The prefix used for `utils.deprecate`
+local DEPRECATE_PREFIX = '\nThe barbar.nvim option '
+
 --- Retrieve some value under `key` from `g:bufferline`, or return a `default` if none was present.
---- PERF: this implementation was profiled be an improvement over `vim.g.bufferline and vim.g.bufferline[key] or default`
 --- @generic T
+--- @param g_bufferline table
 --- @param default? T
 --- @param key string
 --- @return T value
-local function get(key, default)
-  local value = (vim.g.bufferline or {})[key]
+local function get(g_bufferline, key, default)
+  local value = (g_bufferline or {})[key]
   if value == nil or value == vim.NIL then
     return default
   else
     return value
   end
 end
-
---- @class bufferline.options.diagnostics.severity
---- @field enabled boolean
---- @field icon string
-
---- @class bufferline.options.diagnostics
---- @field [1] bufferline.options.diagnostics.severity
---- @field [2] bufferline.options.diagnostics.severity
---- @field [3] bufferline.options.diagnostics.severity
---- @field [4] bufferline.options.diagnostics.severity
-local DEFAULT_DIAGNOSTICS = {
-  [ERROR] = {enabled = false, icon = 'Ⓧ '},
-  [HINT] = {enabled = false, icon = '💡'},
-  [INFO] = {enabled = false, icon = 'ⓘ '},
-  [WARN] = {enabled = false, icon = '⚠️ '},
-}
 
 --- @class bufferline.options.hide
 --- @field alternate? boolean
@@ -42,50 +33,142 @@ local DEFAULT_DIAGNOSTICS = {
 --- @field inactive? boolean
 --- @field visible? boolean
 
---- @alias bufferline.options.icons boolean|"both"|"buffer_number_with_icon"|"buffer_numbers"|"numbers"
+--- @class bufferline.options.icons.diagnostics.severity
+--- @field enabled boolean
+--- @field icon string
+
+--- @class bufferline.options.icons.diagnostics
+--- @field [1] bufferline.options.icons.diagnostics.severity
+--- @field [2] bufferline.options.icons.diagnostics.severity
+--- @field [3] bufferline.options.icons.diagnostics.severity
+--- @field [4] bufferline.options.icons.diagnostics.severity
+local DEFAULT_DIAGNOSTIC_ICONS = {
+  [vim.diagnostic.severity.ERROR] = {enabled = false, icon = 'Ⓧ '},
+  [vim.diagnostic.severity.HINT] = {enabled = false, icon = '💡'},
+  [vim.diagnostic.severity.INFO] = {enabled = false, icon = 'ⓘ '},
+  [vim.diagnostic.severity.WARN] = {enabled = false, icon = '⚠️ '},
+}
+
+--- @class bufferline.options.icons.filetype
+--- @field custom_color? boolean if present, this color will be used for ALL filetype icons
+--- @field enabled? boolean iff `true`, show the `devicons` for the associated buffer's `filetype`.
+
+--- @class bufferline.options.icons.separator
+--- @field left? string a buffer's left separator
+--- @field right? string a buffer's right separator
+
+--- @class bufferline.options.icons.buffer
+--- @field buffer_index? boolean iff `true`, show the index of the associated buffer with respect to the ordering of the buffers in the tabline.
+--- @field buffer_number? boolean iff `true`, show the `bufnr` for the associated buffer.
+--- @field button? false|string the button which is clicked to close / save a buffer, or indicate that it is pinned.
+--- @field diagnostics? bufferline.options.icons.diagnostics the diagnostic icons
+--- @field filetype? bufferline.options.icons.filetype filetype icon options
+--- @field separator? bufferline.options.icons.separator the left-hand separator between buffers in the tabline
+
+--- @class bufferline.options.icons.state: bufferline.options.icons.buffer
+--- @field modified? bufferline.options.icons.buffer the icons used for an modified buffer
+--- @field pinned? bufferline.options.icons.buffer the icons used for a pinned buffer
+
+--- @class bufferline.options.icons: bufferline.options.icons.state
+--- @field alternate? bufferline.options.icons.state the icons used for an alternate buffer
+--- @field current? bufferline.options.icons.state the icons for the current buffer
+--- @field inactive? bufferline.options.icons.state the icons for inactive buffers
+--- @field visible? bufferline.options.icons.state the icons for visible buffers
+
+--- @alias bufferline.options.icons.preset boolean|"both"|"buffer_number_with_icon"|"buffer_numbers"|"numbers"
+
+--- @type {[bufferline.options.icons.preset]: bufferline.options.icons}
+local PRESETS = {
+  [false] = {
+    buffer_number = false,
+    buffer_index = false,
+    filetype = {enabled = false},
+  },
+  [true] = {
+    buffer_number = false,
+    buffer_index = false,
+    filetype = {enabled = true},
+  },
+  both = {
+    buffer_index = true,
+    buffer_number = false,
+    filetype = {enabled = true},
+  },
+  buffer_number_with_icon = {
+    buffer_index = false,
+    buffer_number = true,
+    filetype = {enabled = true},
+  },
+  buffer_numbers = {
+    buffer_index = false,
+    buffer_number = true,
+    filetype = {enabled = false},
+  },
+  numbers = {
+    buffer_index = true,
+    buffer_number = false,
+    filetype = {enabled = false},
+  },
+}
+
+--- @type bufferline.options.icons
+local DEFAULT_ICONS = vim.tbl_extend('keep', PRESETS[true], {
+  button = '',
+  inactive = {separator = {left = '▎', right = ''}},
+  modified = {button = '●'},
+  pinned = {button = ''},
+  separator = {left = '▎', right = ''},
+})
+
+--- A table of options that used to exist, and where they are located now.
+--- @type {[string]: string[]}
+local DEPRECATED_ICON_OPTIONS = {
+  diagnostics = {'diagnostics'},
+  icon_close_tab = {'button'},
+  icon_close_tab_modified = {'modified', 'button'},
+  icon_custom_colors = {'filetype', 'custom_color'},
+  icon_pinned = {'pinned', 'button'},
+  icon_separator_active = {'separator', 'left'},
+  icon_separator_inactive = {'inactive', 'separator', 'left'},
+}
 
 --- @class bufferline.options
 local options = {}
 
+--- @param g_bufferline table
 --- @return boolean enabled
-function options.animation()
-  return get('animation', true)
+function options.animation(g_bufferline)
+  return get(g_bufferline, 'animation', true)
 end
 
+--- @param g_bufferline table
 --- @return boolean enabled
-function options.auto_hide()
-  return get('auto_hide', false)
+function options.auto_hide(g_bufferline)
+  return get(g_bufferline, 'auto_hide', false)
 end
 
+--- @param g_bufferline table
 --- @return boolean enabled
-function options.clickable()
-  return get('clickable', true)
+function options.clickable(g_bufferline)
+  return get(g_bufferline, 'clickable', true)
 end
 
---- @return boolean enabled
-function options.closable()
-  return get('closable', true)
-end
-
+--- @param g_bufferline table
 --- @return bufferline.options.diagnostics
-function options.diagnostics()
-  return tbl_deep_extend('keep', get('diagnostics', {}), DEFAULT_DIAGNOSTICS)
+function options.diagnostics(g_bufferline)
+  return tbl_deep_extend('keep', get(g_bufferline, 'diagnostics', {}), DEFAULT_DIAGNOSTICS)
 end
 
+--- @param g_bufferline table
 --- @return string[] excluded
-function options.exclude_ft()
-  return get('exclude_ft', {})
+function options.exclude_ft(g_bufferline)
+  return get(g_bufferline, 'exclude_ft', {})
 end
 
+--- @param g_bufferline table
 --- @return string[] excluded
-function options.exclude_name()
-  return get('exclude_name', {})
-end
-
---- @param icon_option bufferline.options.icons
---- @return boolean enabled
-function options.file_icons(icon_option)
-  return icon_option == true or icon_option == 'both' or icon_option == 'buffer_number_with_icon'
+function options.exclude_name(g_bufferline)
+  return get(g_bufferline, 'exclude_name', {})
 end
 
 --- @return 'left'|'right' enabled
@@ -93,121 +176,163 @@ function options.focus_on_close()
   return get('focus_on_close', 'left')
 end
 
+--- @param g_bufferline table
 --- @return bufferline.options.hide
-function options.hide()
-  return get('hide', {})
+function options.hide(g_bufferline)
+  return get(g_bufferline, 'hide', {})
 end
 
+--- @param g_bufferline table
 --- @return boolean
-function options.highlight_alternate()
-  return get('highlight_alternate', false)
+function options.highlight_alternate(g_bufferline)
+  return get(g_bufferline, 'highlight_alternate', false)
 end
 
+--- @param g_bufferline table
 --- @return boolean
-function options.highlight_inactive_file_icons()
-  return get('highlight_inactive_file_icons', false)
+function options.highlight_inactive_file_icons(g_bufferline)
+  return get(g_bufferline, 'highlight_inactive_file_icons', false)
 end
 
+--- @param g_bufferline table
 --- @return boolean
-function options.highlight_visible()
-  return get('highlight_visible', true)
+function options.highlight_visible(g_bufferline)
+  return get(g_bufferline, 'highlight_visible', true)
 end
 
---- @return string icon
-function options.icon_close_tab()
-  return get('icon_close_tab', '')
-end
-
---- @return string icon
-function options.icon_close_tab_modified()
-  return get('icon_close_tab_modified', '●')
-end
-
---- @return string icon
-function options.icon_pinned()
-  return get('icon_pinned', '')
-end
-
---- @return string icon
-function options.icon_separator_active()
-  return get('icon_separator_active', '▎')
-end
-
---- @return string icon
-function options.icon_separator_inactive()
-  return get('icon_separator_inactive', '▎')
-end
-
---- @return string icon
-function options.icon_separator_visible()
-  return get('icon_separator_inactive', '▎')
-end
-
+--- @param g_bufferline table
 --- @return bufferline.options.icons
-function options.icons()
-  return get('icons', true)
+function options.icons(g_bufferline)
+  --- @type bufferline.options.icons|bufferline.options.icons.preset
+  local icons = get(g_bufferline, 'icons', {})
+
+  local do_global_option_sync = false
+  if type(icons) ~= 'table' then
+    local preset = PRESETS[icons]
+    utils.deprecate(
+      DEPRECATE_PREFIX .. utils.markdown_inline_code('icons = ' .. vim.inspect(icons)),
+      utils.markdown_inline_code('icons = ' .. vim.inspect(
+        vim.tbl_map(function(v) return v or nil end, preset),
+        {newline = ' ', indent = ''}
+      ))
+    )
+
+    do_global_option_sync = true
+    icons = preset
+  end
+
+  local corrected_options = {}
+  for deprecated_option, new_option in pairs(DEPRECATED_ICON_OPTIONS) do
+    local user_setting = get(g_bufferline, deprecated_option)
+    if user_setting then
+      utils.tbl_set(icons, new_option, user_setting)
+      utils.deprecate(
+        DEPRECATE_PREFIX .. utils.markdown_inline_code(deprecated_option),
+        utils.markdown_inline_code('icons.' .. table_concat(new_option, '.'))
+      )
+
+      do_global_option_sync = true
+      corrected_options[deprecated_option] = vim.NIL
+    end
+  end
+
+  do
+    --- Edge case deprecated option
+    --- @type boolean|nil
+    local closable = get(g_bufferline, 'closable')
+    if closable == false then
+      icons.button = false
+      utils.tbl_set(icons, {'modified', 'button'}, false)
+      utils.deprecate(
+        DEPRECATE_PREFIX .. utils.markdown_inline_code'closable',
+        utils.markdown_inline_code'icons.button' ..
+          ' and ' .. utils.markdown_inline_code'icons.modified.button'
+      )
+
+      do_global_option_sync = true
+      corrected_options.closable = vim.NIL
+    end
+  end
+
+  if do_global_option_sync then
+    corrected_options.icons = icons
+    vim.g.bufferline = tbl_deep_extend('force', g_bufferline, corrected_options)
+  end
+
+  icons = tbl_deep_extend('keep', deepcopy(icons), DEFAULT_ICONS)
+
+  if icons.diagnostics == nil then
+    icons.diagnostics = {}
+  end
+
+  -- NOTE: we do this because `vim.tbl_deep_extend` doesn't deep copy lists
+  for i, default_diagnostic_severity_icons in ipairs(DEFAULT_DIAGNOSTIC_ICONS) do
+    local diagnostic_severity_icons = icons.diagnostics[i] or {}
+
+    if diagnostic_severity_icons.enabled == nil then
+      diagnostic_severity_icons.enabled = default_diagnostic_severity_icons.enabled
+    end
+
+    if diagnostic_severity_icons.icon == nil then
+      diagnostic_severity_icons.icon = default_diagnostic_severity_icons.icon
+    end
+  end
+
+  return icons
 end
 
+--- @param g_bufferline table
 --- @return boolean enabled
-function options.icon_custom_colors()
-  return get('icon_custom_colors', false)
+function options.insert_at_start(g_bufferline)
+  return get(g_bufferline, 'insert_at_start', false)
 end
 
---- @param icon_option bufferline.options.icons
+--- @param g_bufferline table
 --- @return boolean enabled
-function options.index_buffers(icon_option)
-  return icon_option == 'both' or icon_option == 'numbers'
+function options.insert_at_end(g_bufferline)
+  return get(g_bufferline, 'insert_at_end', false)
 end
 
---- @return boolean enabled
-function options.insert_at_start()
-  return get('insert_at_start', false)
-end
-
---- @return boolean enabled
-function options.insert_at_end()
-  return get('insert_at_end', false)
-end
-
+--- @param g_bufferline table
 --- @return string letters
-function options.letters()
-  return get('letters', 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP')
+function options.letters(g_bufferline)
+  return get(g_bufferline, 'letters', 'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP')
 end
 
+--- @param g_bufferline table
 --- @return integer padding
-function options.maximum_padding()
-  return get('maximum_padding', 4)
+function options.maximum_padding(g_bufferline)
+  return get(g_bufferline, 'maximum_padding', 4)
 end
 
+--- @param g_bufferline table
 --- @return integer padding
-function options.minimum_padding()
-  return get('minimum_padding', 1)
+function options.minimum_padding(g_bufferline)
+  return get(g_bufferline, 'minimum_padding', 1)
 end
 
+--- @param g_bufferline table
 --- @return integer length
-function options.maximum_length()
-  return get('maximum_length', 30)
+function options.maximum_length(g_bufferline)
+  return get(g_bufferline, 'maximum_length', 30)
 end
 
+--- @param g_bufferline table
 --- @return nil|string title
-function options.no_name_title()
-  return get('no_name_title')
+function options.no_name_title(g_bufferline)
+  return get(g_bufferline, 'no_name_title')
 end
 
---- @param icon_option bufferline.options.icons
+--- @param g_bufferline table
 --- @return boolean enabled
-function options.number_buffers(icon_option)
-  return icon_option == 'buffer_numbers' or icon_option == 'buffer_number_with_icon'
+function options.semantic_letters(g_bufferline)
+  return get(g_bufferline, 'semantic_letters', true)
 end
 
+--- @param g_bufferline table
 --- @return boolean enabled
-function options.semantic_letters()
-  return get('semantic_letters', true)
-end
-
---- @return boolean enabled
-function options.tabpages()
-  return get('tabpages', true)
+function options.tabpages(g_bufferline)
+  return get(g_bufferline, 'tabpages', true)
 end
 
 return options

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -174,7 +174,7 @@ local function slice_groups_left(groups, width)
 
   local new_groups = {}
 
-  for _, group in ipairs(utils.reverse(groups)) do
+  for _, group in ipairs(utils.list_reverse(groups)) do
     local text_width = strwidth(group.text)
     accumulated_width = accumulated_width + text_width
 

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -586,7 +586,7 @@ local function generate_tabline(bufnrs, refocus)
     -- local is_closing = buffer_data.closing
     local is_pinned = state.is_pinned(bufnr)
 
-    local status = HL_BY_ACTIVITY[activity]
+    local status = Buffer.activities[activity]
     local mod = is_modified and 'Mod' or ''
 
     local separatorPrefix = hl_tabline('Buffer' .. status .. 'Sign')

--- a/lua/bufferline/render.lua
+++ b/lua/bufferline/render.lua
@@ -540,7 +540,7 @@ local function generate_tabline(bufnrs, refocus)
     local icons_option = state.icons(bufnr, activity)
 
     --- Prefix this value to allow an element to be clicked
-    local clickable = click_enabled and ('%' .. bufnr .. '@BufferlineMainClickHandler@') or ''
+    local clickable = click_enabled and ('%' .. bufnr .. '@bufferline#events#main_click_handler@') or ''
 
     --- The name of the buffer
     --- @type bufferline.render.group
@@ -568,7 +568,7 @@ local function generate_tabline(bufnrs, refocus)
     --- @type bufferline.render.group
     local close = {hl = buffer_hl, text = button .. ' '}
     if click_enabled and #button > 0 then
-      close.hl = '%' .. bufnr .. '@BufferlineCloseClickHandler@' .. close.hl
+      close.hl = '%' .. bufnr .. '@bufferline#events#close_click_handler@' .. close.hl
     end
 
     --- The jump letter
@@ -708,7 +708,7 @@ local function generate_tabline(bufnrs, refocus)
 
   result = result ..
     groups_to_string(bufferline_groups) .. -- Render bufferline string
-    '%0@BufferlineMainClickHandler@' .. -- prevent the expansion of the last click group
+    '%0@bufferline#events#main_click_handler@' .. -- prevent the expansion of the last click group
     hl_buffer_tabpage_fill
 
   if layout.actual_width + strwidth(inactive_separator) <= layout.buffers_width and #items > 0 then

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -188,16 +188,8 @@ end
 --- @param hl? string
 --- @return nil
 function state.set_offset(width, text, hl)
-  if vim.deprecate then
-    vim.deprecate('`bufferline.state.set_offset`', '`bufferline.api.set_offset`', '2.0.0', 'barbar.nvim')
-  else
-    utils.notify_once(
-      "`bufferline.state.set_offset` is deprecated, use `bufferline.api.set_offset` instead",
-      vim.log.levels.WARN
-    )
-  end
-
-  require'bufferline.api'.set_offset(width, text, hl)
+  utils.deprecate('`bufferline.state.set_offset`', '`bufferline.api.set_offset`')
+  require.set_offset(width, text, hl)
 end
 
 --- Restore the buffers

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -188,8 +188,12 @@ end
 --- @param hl? string
 --- @return nil
 function state.set_offset(width, text, hl)
-  utils.deprecate('`bufferline.state.set_offset`', '`bufferline.api.set_offset`')
-  require.set_offset(width, text, hl)
+  utils.deprecate(
+    utils.markdown_inline_code'bufferline.state.set_offset',
+    utils.markdown_inline_code'bufferline.api.set_offset'
+  )
+
+  require'bufferline.api'.set_offset(width, text, hl)
 end
 
 --- Restore the buffers

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -96,19 +96,12 @@ function state.get_buffer_data(bufnr)
   end
 
   local data = state.data_by_bufnr[bufnr]
-  if data ~= nil then
-    return data
+  if data == nil then
+    data = {closing = false, pinned = false}
+    state.data_by_bufnr[bufnr] = data
   end
 
-  state.data_by_bufnr[bufnr] = {
-    closing = false,
-    name = nil,
-    position = nil,
-    real_width = nil,
-    width = nil,
-  }
-
-  return state.data_by_bufnr[bufnr]
+  return data
 end
 
 --- Get the list of buffers
@@ -140,7 +133,7 @@ end
 --- @return boolean pinned `true` if `bufnr` is pinned
 function state.is_pinned(bufnr)
   local data = state.get_buffer_data(bufnr)
-  return data and data.pinned
+  return data.pinned
 end
 
 --- Sort the pinned tabs to the left of the bufferline.

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -45,6 +45,14 @@ local function index_of(list, t)
   return nil
 end
 
+--- Use `vim.notify` with a `msg` and log `level`. Integrates with `nvim-notify`.
+--- @param msg string
+--- @param level 0|1|2|3|4|5
+--- @return nil
+local function notify_once_util(msg, level)
+  notify_once(msg, level, {title = 'barbar.nvim'})
+end
+
 --- @param path string
 --- @return string relative_path
 local function relative(path)
@@ -65,6 +73,18 @@ local utils = {
 
     return fnamemodify(path, modifier)
   end,
+
+  deprecate = vim.deprecate and
+    --- Notify a user that something has been deprecated, and that there is an alternative.
+    --- @param name string
+    --- @param alternative string
+    --- @return nil
+    function(name, alternative)
+      vim.deprecate(name, alternative, '2.0.0', 'barbar.nvim')
+    end or
+    function(name, alternative)
+      notify_once_util(name .. ' is deprecated. Use ' .. alternative .. 'instead.', vim.log.levels.WARN)
+    end,
 
   --- Return whether element `n` is in a `list.
   --- @generic T
@@ -158,13 +178,7 @@ local utils = {
     notify(msg, level, {title = 'barbar.nvim'})
   end,
 
-  --- Use `vim.notify` with a `msg` and log `level`. Integrates with `nvim-notify`.
-  --- @param msg string
-  --- @param level 0|1|2|3|4|5
-  --- @return nil
-  notify_once = function(msg, level)
-    notify_once(msg, level, {title = 'barbar.nvim'})
-  end,
+  notify_once = notify_once_util,
 
   relative = relative,
 

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -170,6 +170,13 @@ local utils = {
     return list_slice(list, #list - index_from_end + 1)
   end,
 
+  --- Return "\``s`\`"
+  --- @param s string
+  --- @return string inline_code
+  markdown_inline_code = function(s)
+    return '`' .. s .. '`'
+  end,
+
   --- Use `vim.notify` with a `msg` and log `level`. Integrates with `nvim-notify`.
   --- @param msg string
   --- @param level 0|1|2|3|4|5

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -200,6 +200,33 @@ local utils = {
     end
     return reversed
   end,
+
+  --- Set a `value` in a `tbl` multiple `keys` deep.
+  --
+  --- ```lua
+  --- assert(vim.deep_equal(
+  ---  {a = {b = {c = 'd'}}},
+  ---  tbl_set({}, {'a', 'b', 'c'}, 'd')
+  --- ))
+  --- ```
+  ---
+  --- WARN: this mutates `tbl`!
+  ---
+  --- @generic T
+  --- @param tbl table
+  --- @param keys table<number|string|table>
+  --- @param value T
+  --- @return nil
+  tbl_set = function(tbl, keys, value)
+    local current = tbl
+    for i = 1, #keys - 1 do
+      local key = keys[i]
+      current[key] = current[key] or {}
+      current = current[key]
+    end
+
+    current[keys[#keys]] = value
+  end,
 }
 
 return utils

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -161,6 +161,18 @@ local utils = {
     return relative(path) == path
   end,
 
+  --- Reverse the order of elements in some `list`.
+  --- @generic T
+  --- @param list T[]
+  --- @return T[] reversed
+  list_reverse = function(list)
+    local reversed = {}
+    for i = #list, 1, -1 do
+      table_insert(reversed, list[i])
+    end
+    return reversed
+  end,
+
   --- Run `vim.list_slice` on some `list`, `index`ed from the end of the list.
   --- @generic T
   --- @param list T[]
@@ -188,18 +200,6 @@ local utils = {
   notify_once = notify_once_util,
 
   relative = relative,
-
-  --- Reverse the order of elements in some `list`.
-  --- @generic T
-  --- @param list T[]
-  --- @return T[] reversed
-  reverse = function(list)
-    local reversed = {}
-    for i = #list, 1, -1 do
-      table_insert(reversed, list[i])
-    end
-    return reversed
-  end,
 
   --- Set `fallback` as a secondary source of keys when indexing `tbl`. Example:
   ---

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -201,6 +201,16 @@ local utils = {
     return reversed
   end,
 
+  --- Get `tbl[key]`, return it, and remove it from the `tbl`.
+  --- @param tbl table
+  --- @param key string
+  --- @return any
+  tbl_remove_key = function(tbl, key)
+    local value = rawget(tbl, key)
+    rawset(tbl, key, nil)
+    return value
+  end,
+
   --- Set a `value` in a `tbl` multiple `keys` deep.
   --
   --- ```lua

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -201,6 +201,28 @@ local utils = {
     return reversed
   end,
 
+  --- Set `fallback` as a secondary source of keys when indexing `tbl`. Example:
+  ---
+  --- ```lua
+  --- local fallback = {bar = true}
+  --- local tbl = {}
+  ---
+  --- print(tbl.bar) -- `nil`
+  --- setfallbacktable(tbl, fallback)
+  --- print(tbl.bar) -- `true`
+  ---
+  --- tbl.bar = false
+  --- print(tbl.bar, fallback.bar) -- `false`, `true`
+  --- ```
+  ---
+  --- WARN: this mutates `tbl`!
+  --- @param tbl? table
+  --- @param fallback table
+  --- @return table tbl corresponding to the `tbl` parameter
+  setfallbacktable = function(tbl, fallback)
+    return setmetatable(tbl or {}, {__index = fallback})
+  end,
+
   --- Get `tbl[key]`, return it, and remove it from the `tbl`.
   --- @param tbl table
   --- @param key string


### PR DESCRIPTION
This PR allows customization of the `bufferline.icons` setting per activity / state, like so:

```lua
require'bufferline'.setup {
  icons = {
    -- Configure the base icons on the bufferline.
    buffer_index = false,
    buffer_number = false,
    close = '',
    diagnostics = {…}, -- moved here from the `diagnostics` option
    filetype = {
      -- Sets the icon's highlight group.
      -- If false, will use nvim-web-devicons colors
      custom_colors = false,

      -- Requires `nvim-web-devicons` if `true`
      enabled = true,
    },
    inactive = {separator = {left = '▎'}},
    separator = {left = '▎'},

    -- Configure the icons on the bufferline when modified or pinned.
    -- Supports all the base icon options.
    modified = {button = '●'},
    pinned = {button = '車'},

    -- Configure the icons on the bufferline based on the visibility of a buffer.
    -- Supports all the base icon options, plus `modified` and `pinned`.
    alternate = {filetype = {enabled = false}},
    current = {buffer_index = true},
    inactive = {button = '×'},
    visible = {modified = {buffer_number = false}},
  },
}
```

---

When multiple options match (e.g. `icons.separator`, `icons.modified.separator`, and `icons.alternate.separator`), precedence works as follows:

1. `icons.(alternate|current|inactive|visible).(modified|pinned).foo`, if the buffer is modified or pinned
2. `icons.(modified|pinned).foo`, if the buffer is modified or pinned
3. `icons.(alternate|current|inactive|visible).foo`
4. `icons.foo`

Users who specify their `icons`/`icon_separator_active`/etc options the old way are prompted with a deprecation notice, but _no action is necessary_. The old options are automatically translated to the new format, and this will continue until a theoretical v2.0.0 releases.

---

This seemed like the best compromise between letting a user provide a `function` (my initial proposal) and adhering to the simplicity of user configuration (romgrk's preference).

---

Closes #46.
Closes #243.
Closes #379.