### PR TITLE
fix(icons): being cleared by `:colorscheme`

### DIFF
--- a/lua/bufferline/icons.lua
+++ b/lua/bufferline/icons.lua
@@ -37,11 +37,11 @@ local hl_groups = {}
 local icons = {
   --- Re-highlight all of the groups which have been set before. Checks for updated highlight groups.
   --- @return nil
-  set_highlights = function()
+  set_highlights = vim.schedule_wrap(function()
     for _, group in ipairs(hl_groups) do
       hl_buffer_icon(group.buffer_status, group.icon_hl)
     end
-  end,
+  end),
 
   --- @param bufnr integer
   --- @param buffer_status bufferline.buffer.activity.name

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -210,10 +210,9 @@ function state.set_offset(width, text, hl)
   if vim.deprecate then
     vim.deprecate('`bufferline.state.set_offset`', '`bufferline.api.set_offset`', '2.0.0', 'barbar.nvim')
   else
-    vim.notify_once(
+    utils.notify_once(
       "`bufferline.state.set_offset` is deprecated, use `bufferline.api.set_offset` instead",
-      vim.log.levels.WARN,
-      {title = 'barbar.nvim'}
+      vim.log.levels.WARN
     )
   end
 

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -7,6 +7,7 @@ local get_hl_by_name = vim.api.nvim_get_hl_by_name --- @type function
 local hlexists = vim.fn.hlexists --- @type function
 local list_slice = vim.list_slice
 local notify = vim.notify
+local notify_once = vim.notify_once
 local set_hl = vim.api.nvim_set_hl --- @type function
 
 --- Generate a color.
@@ -153,6 +154,14 @@ local utils = {
   --- @return nil
   notify = function(msg, level)
     notify(msg, level, {title = 'barbar.nvim'})
+  end,
+
+  --- Use `vim.notify` with a `msg` and log `level`. Integrates with `nvim-notify`.
+  --- @param msg string
+  --- @param level 0|1|2|3|4|5
+  --- @return nil
+  notify_once = function(msg, level)
+    notify_once(msg, level, {title = 'barbar.nvim'})
   end,
 
   relative = relative,


### PR DESCRIPTION
The problem was that `nvim-web-devicons` resets its highlights using an autocmd on `ColorScheme`, just to make sure that nothing weird happens to the highlight groups it defines as a result of e.g. `:highlight clear` when switching colorschemes. Our `ColorScheme` event was running too soon (i.e. before the devicons event) and as such the icons were all "cleared" upon calling `:colorscheme`.

Closes #382 