### PR TITLE
feat: `scroll_lock_pinned`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,9 @@ require'barbar'.setup {
   -- Sets the maximum buffer name length.
   maximum_length = 30,
 
+  -- Ensure pinned buffers stay visible in the tabline
+  scroll_lock_pinned = true,
+
   -- If set, the letters for each buffer in buffer-pick mode will be
   -- assigned based on their name. Otherwise or in case all letters are
   -- already assigned, the behavior is to assign letters in order of

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -87,7 +87,7 @@ Highlight groups are created in this way: `Buffer<STATUS><PART>`.
 `<STATUS>`   Meaning
 ---------  --------------------------------------------------
 `Alternate`  The |alternate-file|.
-`Current`    The current buffer.
+`Current`    The |current-file|.
 `Inactive`   |hidden-buffer|s and |inactive-buffer|s.
 `Visible`    |active-buffer|s which are not alternate or current.
 
@@ -162,22 +162,22 @@ exclude_name ~
 focus_on_close ~
   `'left'|'right'`  (default: `'left'`)
   A buffer to this direction will be focused (if it exists) when closing the
-  current buffer.
+  |current-file|.
 
                                                            *barbar-setup.hide*
 hide ~
-  Sets which elements are hidden in the bufferline. Possible options are:
+  Sets which elements are hidden in the 'tabline'. Possible options are:
 
                                                  *barbar-setup.hide.alternate*
   hide.alternate ~
     `boolean`  (default: `false`)
     Controls the visibility of the |alternate-file|.
-    |barbar-setup.highlight_alternate| must be `true`.
+    NOTE: |barbar-setup.highlight_alternate| must be `true`.
 
                                                    *barbar-setup.hide.current*
   hide.current ~
     `boolean`  (default: `false`)
-    Controls the visibility of the current buffer.
+    Controls the visibility of the |current-file|.
 
                                                 *barbar-setup.hide.extensions*
   hide.extensions ~
@@ -193,7 +193,7 @@ hide ~
   hide.visible ~
     `boolean`  (default: `false`)
     Controls visibility of |active-buffer|s.
-    |barbar-setup.highlight_visible| must be `true`.
+    NOTE: |barbar-setup.highlight_visible| must be `true`.
 
                                             *barbar-setup.highlight_alternate*
 highlight_alternate ~
@@ -242,10 +242,10 @@ icons ~
        [vim.diagnostic.severity.INFO] = {enabled = false, icon = 'ⓘ '},
        [vim.diagnostic.severity.WARN] = {enabled = false, icon = '⚠️ '},
     }
-<   Enables or disables showing diagnostics in the bufferline. The options
+<   Enables or disables showing diagnostics in the 'tabline'. The options
     are:
     - `enabled`, whether this diagnostics of this severity are shown in the
-      bufferline.
+      'tabline'.
     - `icon`, which controls what icon accompanies the number of diagnostics.
 
                                    *barbar-setup.icons.filetype.custom_colors*
@@ -311,7 +311,7 @@ icons ~
                                                   *barbar-setup.icons.current*
   icons.current ~
     `table`
-    The icons which should be used for current buffer.
+    The icons which should be used for |current-file|.
     Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
     etc) as well as `modified` and `pinned`.
 
@@ -346,14 +346,14 @@ icons ~
 insert_at_start ~
   `boolean`  (default: `false`)
   If true, new buffers appear at the start of the list. Default is to
-  open after the current buffer.
+  open after the |current-file|.
   Has priority over |barbar-setup.insert_at_end|
 
                                                   *barbar-setup.insert_at_end*
 insert_at_end ~
   `boolean`   (default: `false`)
   If true, new buffers appear at the end of the list. Default is to
-  open after the current buffer.
+  open after the |current-file|.
 
                                                         *barbar-setup.letters*
 letters ~
@@ -382,6 +382,11 @@ no_name_title ~
   `string`  (default: `nil`)
   Sets the name of unnamed buffers. By default format is `'[Buffer X]'`
   where `X` is the buffer number. But only a static string is accepted here.
+
+                                             *barbar-setup.scroll_lock.pinned*
+scroll_lock_pinned ~
+  `boolean`  (default: `false`)
+  If `true`, pinned buffers will always be shown in the 'tabline'.
 
                                                *barbar-setup.semantic_letters*
 semantic_letters ~

--- a/lua/barbar/bbye.lua
+++ b/lua/barbar/bbye.lua
@@ -81,11 +81,16 @@ local function get_focus_on_close(closing_number)
 
   if #state_bufnrs < 1 then -- all of the buffers are excluded or unlisted
     local open_bufnrs = list_bufs()
-    if focus_on_close == 'right' then
-      open_bufnrs = utils.list_reverse(open_bufnrs)
+
+    local start, end_, step
+    if focus_on_close == 'left' then
+      start, end_, step = 1, #open_bufnrs, 1
+    else
+      start, end_, step = #open_bufnrs, 1, -1
     end
 
-    for _, nr in ipairs(open_bufnrs) do
+    for i = start, end_, step do
+      local nr = open_bufnrs[i]
       if buf_get_option(nr, 'buflisted') then
         return nr -- there was a listed buffer open, focus it.
       end
@@ -194,7 +199,9 @@ function bbye.delete(action, force, buffer, mods)
 
   -- For cases where adding buffers causes new windows to appear or hiding some
   -- causes windows to disappear and thereby decrement, loop backwards.
-  for _, window_number in ipairs(utils.list_reverse(list_wins())) do
+  local wins = list_wins()
+  for i = #wins, 1, -1 do
+    local window_number = wins[i]
     if win_get_buf(window_number) == buffer_number then
       set_current_win(window_number)
 

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -123,6 +123,7 @@ local DEPRECATED_OPTIONS = {
 --- @field maximum_padding integer
 --- @field minimum_padding integer
 --- @field no_name_title string
+--- @field scroll_lock_pinned boolean
 --- @field semantic_letters boolean
 --- @field tabpages boolean
 
@@ -208,6 +209,7 @@ function config.setup(user_config)
     maximum_padding = 4,
     minimum_padding = 1,
     no_name_title = nil,
+    scroll_lock_pinned = false,
     semantic_letters = true,
     tabpages = true,
   })

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -13,6 +13,7 @@ local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local list_bufs = vim.api.nvim_list_bufs --- @type function
 local list_extend = vim.list_extend
 local severity = vim.diagnostic.severity --- @type {[integer]: string, [string]: integer}
+local tbl_contains = vim.tbl_contains
 local tbl_filter = vim.tbl_filter
 
 local Buffer = require'barbar.buffer'
@@ -116,10 +117,10 @@ function state.get_buffer_list()
 
   for _, bufnr in ipairs(list_bufs()) do
     if buf_get_option(bufnr, 'buflisted') and
-      not utils.has(exclude_ft, buf_get_option(bufnr, 'filetype'))
+      not tbl_contains(exclude_ft, buf_get_option(bufnr, 'filetype'))
     then
       local name = buf_get_name(bufnr)
-      if not utils.has(exclude_name, utils.basename(name, hide_extensions)) then
+      if not tbl_contains(exclude_name, utils.basename(name, hide_extensions)) then
         table_insert(result, bufnr)
       end
     end

--- a/lua/barbar/utils.lua
+++ b/lua/barbar/utils.lua
@@ -136,15 +136,6 @@ local utils = {
       notify_once_util(name .. ' is deprecated. Use ' .. alternative .. 'instead.', vim.log.levels.WARN)
     end,
 
-  --- Return whether element `n` is in a `list.
-  --- @generic T
-  --- @param list T[]
-  --- @param t T
-  --- @return boolean
-  has = function(list, t)
-    return index_of(list, t) ~= nil
-  end,
-
   --- utilities for working with highlight groups.
   --- @class barbar.utils.hl
   hl = {


### PR DESCRIPTION
Allows users to lock elements in the tabline as visible.

```lua
require'barbar'.setup {
  scroll_lock_pinned = true,
}
```

---

If I can get it working, I will use #408 instead as it will be more compatible with #175.

---

Todo:

* [ ] Discuss name
* [x] Implement feature in `render`

---

Closes #393