### PR TITLE
feat: implement buffer restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ nnoremap <silent>    <A-p> <Cmd>BufferPin<CR>
 
 " Close buffer
 nnoremap <silent>    <A-c> <Cmd>BufferClose<CR>
+" Restore buffer
+nnoremap <silent>    <A-s-c> <Cmd>BufferRestore<CR>
 
 " Wipeout buffer
 "                          :BufferWipeout

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -53,6 +53,8 @@ The name of each command should be descriptive enough for you to use it.
 
     " Close buffer
     nnoremap <silent>    <A-c> <Cmd>BufferClose<CR>
+    " Restore buffer
+    nnoremap <silent>    <A-s-c> <Cmd>BufferRestore<CR>
 
     " Wipeout buffer
     "                          :BufferWipeout

--- a/lua/barbar.lua
+++ b/lua/barbar.lua
@@ -192,6 +192,12 @@ function barbar.setup(user_config)
     {count = true, desc = 'Scroll the bufferline right'}
   )
 
+  create_user_command(
+    'BufferRestore',
+    api.restore_buffer,
+    {desc = 'Restore the last recently closed buffer'}
+  )
+
   -- Setup barbar
   events.on_option_changed(user_config)
   events.enable()

--- a/lua/barbar/api.lua
+++ b/lua/barbar/api.lua
@@ -159,6 +159,11 @@ function api.close_buffers_right()
   render.update()
 end
 
+-- Restore last recently closed buffer
+function api.restore_buffer()
+  state.pop_recently_closed()
+end
+
 --- Set the current buffer to the `number`
 --- @param index integer
 --- @return nil

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -67,6 +67,9 @@ end)
 function events.enable()
   local augroup_misc, augroup_render = events.augroups()
 
+  create_autocmd({'VimEnter'}, { callback = state.load_recently_closed, group = augroup_misc })
+  create_autocmd({'VimLeave'}, { callback = state.save_recently_closed, group = augroup_misc })
+
   create_autocmd({'BufNewFile', 'BufReadPost'}, {
     callback = function(tbl) JumpMode.assign_next_letter(tbl.buf) end,
     group = augroup_misc,
@@ -75,6 +78,7 @@ function events.enable()
   create_autocmd({'BufDelete', 'BufWipeout'}, {
     callback = vim.schedule_wrap(function(tbl)
       JumpMode.unassign_letter_for(tbl.buf)
+      state.push_recently_closed(tbl.file)
       render.update()
     end),
     group = augroup_render,

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -368,21 +368,26 @@ end
 --- @return nil
 function state.load_recently_closed()
   local file, open_err = io.open(CACHE_PATH, 'r')
+
+  -- Ignore if the file doesn't exist or isn't readable
   if open_err ~= nil then
-    return utils.notify('Recently closed buffer list does not exist; skipping. ' .. CACHE_PATH, vim.log.levels.INFO)
+    return
   elseif file == nil then
-    return utils.notify('Could not open ' .. CACHE_PATH, vim.log.levels.ERROR)
+    return
   end
+
   local content, read_err = file:read('*a')
   if read_err ~= nil then
     return utils.notify(read_err, vim.log.levels.ERROR)
   end
+
   local success, close_err = file:close()
   if close_err ~= nil then
-    return utils.notify(close_err, vim.log.levels.ERROR)
+    return
   elseif success == false then
-    return utils.notify('Could not close ' .. CACHE_PATH, vim.log.levels.ERROR)
+    return
   end
+
   pcall(function()
     local saved_state = json_decode(content, { luanil = { array = true, object = true } })
     if saved_state.recently_closed ~= nil then

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -8,20 +8,28 @@ local table_remove = table.remove
 local buf_get_name = vim.api.nvim_buf_get_name --- @type function
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
 local bufadd = vim.fn.bufadd --- @type function
-local stdpath = vim.fn.stdpath --- @type function
-local json_encode = vim.fn.json_encode --- @type function
-local json_decode = vim.fn.json_decode --- @type function
+local bufexists = vim.fn.bufexists
+local bufname = vim.fn.bufname
+local command = vim.api.nvim_command
+local fnamemodify = vim.fn.fnamemodify
+local json_encode = vim.json.encode --- @type function
+local json_decode = vim.json.decode --- @type function
 local deepcopy = vim.deepcopy
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local list_bufs = vim.api.nvim_list_bufs --- @type function
 local list_extend = vim.list_extend
 local list_slice = vim.list_slice
 local severity = vim.diagnostic.severity --- @type {[integer]: string, [string]: integer}
+local stdpath = vim.fn.stdpath --- @type function
+local tbl_contains = vim.tbl_contains
 local tbl_filter = vim.tbl_filter
+local tbl_map = vim.tbl_map
 
 local Buffer = require'barbar.buffer'
 local config = require'barbar.config'
 local utils = require'barbar.utils'
+
+local CACHE_PATH = stdpath('cache') .. '/barbar.json'
 
 --- Set `higher` to have higher priority than `lower` when resolving the `icons` option.
 --- @param higher? barbar.config.options.icons.buffer
@@ -192,21 +200,26 @@ end
 --- @return nil
 function state.push_recently_closed(filepath)
   if filepath ~= nil and filepath ~= '' then
-    table.insert(state.recently_closed, 1, filepath)
+    table_insert(state.recently_closed, 1, fnamemodify(filepath, ':p'))
     state.recently_closed = list_slice(state.recently_closed, 1, 20)
   end
 end
 
 --- Restore a recently closed buffer
---- @return string | nil
+--- @return nil
 function state.pop_recently_closed()
-  if #state.recently_closed == 0 then
-    return nil
+  local open_filepaths =
+    tbl_map(function(bufnr) return fnamemodify(bufname(bufnr), ':p') end, state.buffers)
+
+  while #state.recently_closed > 0 do
+    local filepath = state.recently_closed[1]
+    state.recently_closed = list_slice(state.recently_closed, 2, 20)
+
+    if not tbl_contains(open_filepaths, filepath) then
+      command(string.format('edit %s', filepath))
+      break
+    end
   end
-  local filepath = state.recently_closed[1]
-  state.recently_closed = list_slice(state.recently_closed, 2, 20)
-  vim.cmd(string.format('edit %s', filepath))
-  return filepath
 end
 
 -- Read/write state
@@ -329,35 +342,53 @@ end
 --- Save recently_closed list
 --- @return nil
 function state.save_recently_closed()
-  local filepath = stdpath('cache') .. '/barbar.json'
-  local file = io.open(filepath, 'w+')
-  if file == nil then
-    return
+  local file, open_err = io.open(CACHE_PATH, 'w')
+  if open_err ~= nil then
+    return utils.notify(open_err, vim.log.levels.ERROR)
+  elseif file == nil then
+    return utils.notify('Could not open ' .. CACHE_PATH, vim.log.levels.ERROR)
   end
-
-  local encoded_state = json_encode({
-    recently_closed = state.recently_closed,
-  })
-
-  file:write(encoded_state)
-  file:close()
+  do
+    local _, write_err = file:write(json_encode({
+      recently_closed = state.recently_closed,
+    }))
+    if write_err ~= nil then
+      return utils.notify(write_err, vim.log.levels.ERROR)
+    end
+  end
+  local success, close_err = file:close()
+  if close_err ~= nil then
+    return utils.notify(close_err, vim.log.levels.ERROR)
+  elseif success == false then
+    return utils.notify('Could not close ' .. CACHE_PATH, vim.log.levels.ERROR)
+  end
 end
 
 --- Save recently_closed list
 --- @return nil
 function state.load_recently_closed()
-  local filepath = stdpath('cache') .. '/barbar.json'
-  local file = io.open(filepath, 'r')
-  if (file == nil) then
-    return
+  local file, open_err = io.open(CACHE_PATH, 'r')
+  if open_err ~= nil then
+    return utils.notify('Recently closed buffer list does not exist; skipping. ' .. CACHE_PATH, vim.log.levels.INFO)
+  elseif file == nil then
+    return utils.notify('Could not open ' .. CACHE_PATH, vim.log.levels.ERROR)
   end
-  local content = file:read('*a')
-  file:close()
-
-  local saved_state = json_decode(content)
-  if saved_state.recently_closed ~= nil then
-    state.recently_closed = saved_state.recently_closed
+  local content, read_err = file:read('*a')
+  if read_err ~= nil then
+    return utils.notify(read_err, vim.log.levels.ERROR)
   end
+  local success, close_err = file:close()
+  if close_err ~= nil then
+    return utils.notify(close_err, vim.log.levels.ERROR)
+  elseif success == false then
+    return utils.notify('Could not close ' .. CACHE_PATH, vim.log.levels.ERROR)
+  end
+  pcall(function()
+    local saved_state = json_decode(content, { luanil = { array = true, object = true } })
+    if saved_state.recently_closed ~= nil then
+      state.recently_closed = saved_state.recently_closed
+    end
+  end)
 end
 
 -- Exports

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -8,10 +8,14 @@ local table_remove = table.remove
 local buf_get_name = vim.api.nvim_buf_get_name --- @type function
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
 local bufadd = vim.fn.bufadd --- @type function
+local stdpath = vim.fn.stdpath --- @type function
+local json_encode = vim.fn.json_encode --- @type function
+local json_decode = vim.fn.json_decode --- @type function
 local deepcopy = vim.deepcopy
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local list_bufs = vim.api.nvim_list_bufs --- @type function
 local list_extend = vim.list_extend
+local list_slice = vim.list_slice
 local severity = vim.diagnostic.severity --- @type {[integer]: string, [string]: integer}
 local tbl_filter = vim.tbl_filter
 
@@ -74,11 +78,13 @@ end
 --- @field buffers integer[] the open buffers, in visual order.
 --- @field data_by_bufnr {[integer]: barbar.state.data} the buffer data indexed on buffer number
 --- @field pins {[integer]: boolean} whether a buffer is pinned
+--- @field recently_closed string[] the list of recently closed paths
 local state = {
   is_picking_buffer = false,
   loading_session = false,
   buffers = {},
   data_by_bufnr = {},
+  recently_closed = {},
 
   --- The offset of the tabline (from the left).
   --- @class barbar.render.offset
@@ -179,6 +185,28 @@ function state.close_buffer(bufnr, do_name_update)
   if do_name_update then
     state.update_names()
   end
+end
+
+--- Store a recently closed buffer
+--- @param filepath string | nil
+--- @return nil
+function state.push_recently_closed(filepath)
+  if filepath ~= nil and filepath ~= '' then
+    table.insert(state.recently_closed, 1, filepath)
+    state.recently_closed = list_slice(state.recently_closed, 1, 20)
+  end
+end
+
+--- Restore a recently closed buffer
+--- @return string | nil
+function state.pop_recently_closed()
+  if #state.recently_closed == 0 then
+    return nil
+  end
+  local filepath = state.recently_closed[1]
+  state.recently_closed = list_slice(state.recently_closed, 2, 20)
+  vim.cmd(string.format('edit %s', filepath))
+  return filepath
 end
 
 -- Read/write state
@@ -294,6 +322,42 @@ function state.icons(bufnr, activity)
   end
 
   return buffer_icons
+end
+
+-- Save/load state
+
+--- Save recently_closed list
+--- @return nil
+function state.save_recently_closed()
+  local filepath = stdpath('cache') .. '/barbar.json'
+  local file = io.open(filepath, 'w+')
+  if file == nil then
+    return
+  end
+
+  local encoded_state = json_encode({
+    recently_closed = state.recently_closed,
+  })
+
+  file:write(encoded_state)
+  file:close()
+end
+
+--- Save recently_closed list
+--- @return nil
+function state.load_recently_closed()
+  local filepath = stdpath('cache') .. '/barbar.json'
+  local file = io.open(filepath, 'r')
+  if (file == nil) then
+    return
+  end
+  local content = file:read('*a')
+  file:close()
+
+  local saved_state = json_decode(content)
+  if saved_state.recently_closed ~= nil then
+    state.recently_closed = saved_state.recently_closed
+  end
 end
 
 -- Exports


### PR DESCRIPTION
Closes #202 

Implement basic buffer restore functionality.

This could use some more thought, in particular with regards to session management. My own config has session management enabled so that the closed buffer list is session-local, but I can't make the same assumptions here that I use for my own config so I'll just go with a simpler implementation for now.

