### PR TITLE
fix: dont call setup if user did it

### DIFF
--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -127,11 +127,17 @@ local DEPRECATED_OPTIONS = {
 --- @field tabpages boolean
 
 --- @class barbar.config
+--- @field did_initialize boolean
 --- @field options barbar.config.options
-local config = {options = {}}
+local config = {
+  did_initialize = false,
+  options = {},
+}
 
 --- @param user_config? table
 function config.setup(user_config)
+  config.did_initialize = true
+
   if type(user_config) ~= 'table' then
     user_config = {}
   end

--- a/plugin/barbar.lua
+++ b/plugin/barbar.lua
@@ -14,4 +14,6 @@ if user_config then
   )
 end
 
-require'bufferline'.setup(user_config)
+if require'barbar.config'.did_initialize == false then
+  require'bufferline'.setup(user_config)
+end


### PR DESCRIPTION
Closes #402 

Don't auto-call setup if the user did it, as it clears the user options.