### PR TITLE
feat: pinned buffers stay visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,11 @@ map('n', '<Space>bw', '<Cmd>BufferOrderByWindowNumber<CR>', opts)
 
 ```lua
 vim.g.barbar_auto_setup = false -- disable auto-setup
-require'barbar'.setup { -- Set barbar's options
+require'barbar'.setup {
+  -- WARN: do not copy everything below into your config!
+  --       It is just an example of what configuration options there are.
+  --       The defaults are suitable for most people.
+
   -- Enable/disable animations
   animation = true,
 
@@ -305,7 +309,7 @@ require'barbar'.setup { -- Set barbar's options
     -- Configure the icons on the bufferline when modified or pinned.
     -- Supports all the base icon options.
     modified = {button = '●'},
-    pinned = {button = '車'},
+    pinned = {button = '車', filename = true, separator = {right = ''}},
 
     -- Configure the icons on the bufferline based on the visibility of a buffer.
     -- Supports all the base icon options, plus `modified` and `pinned`.

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -265,6 +265,11 @@ icons ~
       }}}
 <
 
+                                                 *barbar-setup.icons.filename*
+  icons.filename ~
+    `boolean`  (default: `true`)
+    If `true`, show the name of the file.
+
                                    *barbar-setup.icons.filetype.custom_colors*
   icons.filetype.custom_colors ~
     `boolean`  (default: `false`)
@@ -309,7 +314,13 @@ icons ~
 
                                                    *barbar-setup.icons.pinned*
   icons.pinned ~
-    `table`  (default: `{button = ''}`)
+    `table`  (default: >
+                    {
+                      button = false,
+                      filename = false,
+                      separator = {right = ' '},
+                    }
+<           )
     The icons which should be used for a pinned buffer.
     Supports all the base options (e.g. `buffer_index`, `filetype.enabled`,
     etc)
@@ -317,7 +328,7 @@ icons ~
   Example: >
     require'barbar'.setup {icons = {
       modified = {separator = '⋄'},
-      pinned = {button = '車'},
+      pinned = {button = '車', filename = true},
     }}
 <
 

--- a/lua/barbar/api.lua
+++ b/lua/barbar/api.lua
@@ -213,22 +213,23 @@ function api.goto_buffer_relative(steps)
   set_current_buf(state.buffers[(idx + steps - 1) % #state.buffers + 1])
 end
 
-local move_animation = nil
-local move_animation_data = nil
+local move_animation = nil --- @type nil|barbar.animate.state
+local move_animation_data = {
+  next_positions = nil, --- @type nil|integer[]
+  previous_positions = nil --- @type nil|integer[]
+}
 
 --- An incremental animation for `move_buffer_animated`.
 --- @return nil
 local function move_buffer_animated_tick(ratio, current_animation)
-  local data = move_animation_data
-
   for _, current_number in ipairs(Layout.buffers) do
     local current_data = state.get_buffer_data(current_number)
 
     if current_animation.running == true then
       current_data.position = animate.lerp(
         ratio,
-        data.previous_positions[current_number],
-        data.next_positions[current_number]
+        (move_animation_data.previous_positions or {})[current_number],
+        (move_animation_data.next_positions or {})[current_number]
       )
     else
       current_data.position = nil
@@ -240,7 +241,8 @@ local function move_buffer_animated_tick(ratio, current_animation)
 
   if current_animation.running == false then
     move_animation = nil
-    move_animation_data = nil
+    move_animation_data.next_positions = nil
+    move_animation_data.previous_positions = nil
   end
 end
 

--- a/lua/barbar/bbye.lua
+++ b/lua/barbar/bbye.lua
@@ -81,11 +81,16 @@ local function get_focus_on_close(closing_number)
 
   if #state_bufnrs < 1 then -- all of the buffers are excluded or unlisted
     local open_bufnrs = list_bufs()
-    if focus_on_close == 'right' then
-      open_bufnrs = utils.list_reverse(open_bufnrs)
+
+    local start, end_, step
+    if focus_on_close == 'left' then
+      start, end_, step = 1, #open_bufnrs, 1
+    else
+      start, end_, step = #open_bufnrs, 1, -1
     end
 
-    for _, nr in ipairs(open_bufnrs) do
+    for i = start, end_, step do
+      local nr = open_bufnrs[i]
       if buf_get_option(nr, 'buflisted') then
         return nr -- there was a listed buffer open, focus it.
       end
@@ -194,7 +199,9 @@ function bbye.delete(action, force, buffer, mods)
 
   -- For cases where adding buffers causes new windows to appear or hiding some
   -- causes windows to disappear and thereby decrement, loop backwards.
-  for _, window_number in ipairs(utils.list_reverse(list_wins())) do
+  local wins = list_wins()
+  for i = #wins, 1, -1 do
+    local window_number = wins[i]
     if win_get_buf(window_number) == buffer_number then
       set_current_win(window_number)
 

--- a/lua/barbar/buffer.lua
+++ b/lua/barbar/buffer.lua
@@ -105,6 +105,21 @@ local buffer = {
 
   get_activity = get_activity,
 
+  --- @param activity barbar.buffer.activity.name
+  --- @param modified boolean
+  --- @param pinned boolean
+  --- @return barbar.config.options.icons.buffer
+  get_icons = function(activity, modified, pinned)
+    local icons_option = config.options.icons[activity:lower()]
+    if pinned then
+      icons_option = icons_option.pinned
+    elseif modified then
+      icons_option = icons_option.modified
+    end
+
+    return icons_option
+  end,
+
   --- @param buffer_number integer
   --- @param hide_extensions boolean? if `true`, exclude the extension of the file
   --- @return string name

--- a/lua/barbar/buffer.lua
+++ b/lua/barbar/buffer.lua
@@ -86,18 +86,18 @@ local buffer = {
   --- For each severity in `diagnostics`: if it is enabled, and there are diagnostics associated with it in the `buffer_number` provided, call `f`.
   --- @param buffer_number integer the buffer number to count diagnostics in
   --- @param diagnostics barbar.config.options.icons.diagnostics the user configuration for diagnostics
-  --- @param f fun(count: integer, diagnostic: barbar.config.options.icons.diagnostics.severity, severity: integer) the function to run when diagnostics of a specific severity are enabled and present in the `buffer_number`
+  --- @param f fun(count: integer, severity_idx: integer, severity_option: barbar.config.options.icons.diagnostics.severity) the function to run when diagnostics of a specific severity are enabled and present in the `buffer_number`
   --- @return nil
   for_each_counted_enabled_diagnostic = function(buffer_number, diagnostics, f)
     local count
-    for severity, severity_config in ipairs(diagnostics) do
-      if severity_config.enabled then
+    for severity_idx, severity_option in ipairs(diagnostics) do
+      if severity_option.enabled then
         if count == nil then
           count = count_diagnostics(buffer_number)
         end
 
-        if count[severity] > 0 then
-          f(count[severity], severity_config, severity)
+        if count[severity_idx] > 0 then
+          f(count[severity_idx], severity_idx, severity_option)
         end
       end
     end

--- a/lua/barbar/buffer.lua
+++ b/lua/barbar/buffer.lua
@@ -85,8 +85,8 @@ local buffer = {
 
   --- For each severity in `diagnostics`: if it is enabled, and there are diagnostics associated with it in the `buffer_number` provided, call `f`.
   --- @param buffer_number integer the buffer number to count diagnostics in
-  --- @param diagnostics barbar.config.options.icons.diagnostics the user configuration for diagnostics
-  --- @param f fun(count: integer, severity_idx: integer, severity_option: barbar.config.options.icons.diagnostics.severity) the function to run when diagnostics of a specific severity are enabled and present in the `buffer_number`
+  --- @param diagnostics barbar.config.options.icons.buffer.diagnostics the user configuration for diagnostics
+  --- @param f fun(count: integer, severity_idx: integer, option: barbar.config.options.icons.diagnostics.severity) the function to run when diagnostics of a specific severity are enabled and present in the `buffer_number`
   --- @return nil
   for_each_counted_enabled_diagnostic = function(buffer_number, diagnostics, f)
     local count

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -255,6 +255,39 @@ function config.setup(options)
       diagnostic_severity_icons.icon = default_diagnostic_severity_icons.icon
     end
   end
+
+  local icons = config.options.icons
+
+  --- `config.options.icons` without the recursive structure
+  --- @type barbar.config.options.icons.buffer
+  local base_options = {
+    buffer_index = icons.buffer_index,
+    buffer_number = icons.buffer_number,
+    filename = icons.filename,
+    button = icons.button,
+    diagnostics = icons.diagnostics,
+    filetype = icons.filetype,
+    separator = icons.separator,
+  }
+
+  -- resolve all of the icons for the activities
+  for _, activity in ipairs {'alternate', 'current', 'inactive', 'visible'} do
+    local activity_options = tbl_deep_extend('keep', config.options.icons[activity] or {}, base_options)
+    config.options.icons[activity] = activity_options
+    config.options.icons[activity].modified = tbl_deep_extend(
+      'keep',
+      config.options.icons[activity].modified or {},
+      config.options.icons.modified or {},
+      activity_options
+    )
+
+    config.options.icons[activity].pinned = tbl_deep_extend(
+      'keep',
+      config.options.icons[activity].pinned or {},
+      config.options.icons.pinned or {},
+      activity_options
+    )
+  end
 end
 
 return config

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -18,7 +18,7 @@ local DEPRECATE_PREFIX = '\nThe barbar.nvim option '
 --- @field enabled boolean
 --- @field icon string
 
---- @class barbar.config.options.icons.diagnostics
+--- @class barbar.config.options.icons.buffer.diagnostics
 --- @field [1] barbar.config.options.icons.diagnostics.severity
 --- @field [2] barbar.config.options.icons.diagnostics.severity
 --- @field [3] barbar.config.options.icons.diagnostics.severity
@@ -30,21 +30,22 @@ local DEFAULT_DIAGNOSTIC_ICONS = {
   [vim.diagnostic.severity.WARN] = {enabled = false, icon = '⚠️ '},
 }
 
---- @class barbar.config.options.icons.filetype
+--- @class barbar.config.options.icons.buffer.filetype
 --- @field custom_colors? boolean if present, this color will be used for ALL filetype icons
 --- @field enabled? boolean iff `true`, show the `devicons` for the associated buffer's `filetype`.
 
---- @class barbar.config.options.icons.separator
+--- @class barbar.config.options.icons.buffer.separator
 --- @field left? string a buffer's left separator
 --- @field right? string a buffer's right separator
 
 --- @class barbar.config.options.icons.buffer
 --- @field buffer_index? boolean iff `true`, show the index of the associated buffer with respect to the ordering of the buffers in the tabline.
 --- @field buffer_number? boolean iff `true`, show the `bufnr` for the associated buffer.
+--- @field filename? boolean iff `true`, show the filename
 --- @field button? false|string the button which is clicked to close / save a buffer, or indicate that it is pinned.
---- @field diagnostics? barbar.config.options.icons.diagnostics the diagnostic icons
---- @field filetype? barbar.config.options.icons.filetype filetype icon options
---- @field separator? barbar.config.options.icons.separator the left-hand separator between buffers in the tabline
+--- @field diagnostics? barbar.config.options.icons.buffer.diagnostics the diagnostic icons
+--- @field filetype? barbar.config.options.icons.buffer.filetype filetype icon options
+--- @field separator? barbar.config.options.icons.buffer.separator the left-hand separator between buffers in the tabline
 
 --- @class barbar.config.options.icons.state: barbar.config.options.icons.buffer
 --- @field modified? barbar.config.options.icons.buffer the icons used for an modified buffer
@@ -198,7 +199,7 @@ function config.setup(options)
     end
   end
 
-  config.options = tbl_deep_extend('keep', options, {
+  local default_options = {
     animation = true,
     auto_hide = false,
     clickable = true,
@@ -214,10 +215,11 @@ function config.setup(options)
       buffer_number = false,
       button = '',
       diagnostics = {},
+      filename = true,
       filetype = {enabled = true},
       inactive = {separator = {left = '▎', right = ''}},
       modified = {button = '●'},
-      pinned = {button = ''},
+      pinned = {button = false, filename = false},
       separator = {left = '▎', right = ''},
     },
     insert_at_end = false,
@@ -230,7 +232,16 @@ function config.setup(options)
     semantic_letters = true,
     sidebar_filetypes = {},
     tabpages = true,
-  })
+  }
+
+  do
+    local pinned_icons = options.icons and options.icons.pinned
+    if pinned_icons == nil or pinned_icons.button == false or #pinned_icons.button < 1 then
+      default_options.icons.pinned.separator = {right = ' '}
+    end
+  end
+
+  config.options = tbl_deep_extend('keep', options, default_options)
 
   -- NOTE: we do this because `vim.tbl_deep_extend` doesn't deep copy lists
   for i, default_diagnostic_severity_icons in ipairs(DEFAULT_DIAGNOSTIC_ICONS) do

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -266,7 +266,7 @@ function events.enable()
         end
 
         -- escape quotes
-        table_insert(buffers, {name = name, pinned =  state.get_buffer_data(bufnr).pinned})
+        table_insert(buffers, {name = name, pinned = state.is_pinned(bufnr)})
       end
 
       vim.g.Bufferline__session_restore = "lua require'barbar.state'.restore_buffers " ..

--- a/lua/barbar/layout.lua
+++ b/lua/barbar/layout.lua
@@ -5,7 +5,6 @@
 local floor = math.floor
 local max = math.max
 local min = math.min
-local rshift = bit.rshift
 local table_insert = table.insert
 
 local get_option = vim.api.nvim_get_option --- @type function
@@ -20,62 +19,98 @@ local state = require'barbar.state'
 --- The number of sides of each buffer in the tabline.
 local SIDES_OF_BUFFER = 2
 
+--- The length of a slash (`#'/'`)
+local SLASH_LEN = #'/'
+
+--- The length of one space (`#' '`)
+local SPACE_LEN = #' '
+
 --- @class barbar.layout.data
---- @field actual_width integer
---- @field available_width integer
---- @field base_widths integer[]
---- @field buffers_width integer
---- @field padding_width integer
---- @field tabpages_width integer
---- @field used_width integer
+--- @field actual_width integer the `used_width` plus the `padding_width` allocated to each buffer
+--- @field base_widths integer[] the minimum amount of space taken up by each buffer
+--- @field buffers_width integer the amount of space available to be taken up by buffers
+--- @field padding_width integer the amount of padding used on each side of each buffer
+--- @field tabpages_width integer the amount of space taken up by the tabpage indicator
+--- @field scroll_max integer the maximum position which can be scrolled to
+--- @field used_width integer the sum of the `base_widths`
 
 --- @class barbar.Layout
 --- @field buffers integer[] different from `state.buffers` in that the `hide` option is respected. Only updated when calling `calculate_buffers_width`.
 local Layout = { buffers = {} }
 
---- The number of characters needed to represent the tabpages.
---- @return integer width
-function Layout.calculate_tabpages_width()
-  local current = tabpagenr()
-  local total   = tabpagenr('$')
-  if not config.options.tabpages or total == 1 then
-    return 0
-  end
-  return 1 + tostring(current):len() + 1 + tostring(total):len() + 1
+--- Calculate the current layout of the bufferline.
+--- @return barbar.layout.data
+function Layout.calculate()
+  local available_width = get_option'columns'
+  available_width = available_width - state.offset.left.width - state.offset.right.width
+
+  local used_width, base_widths = Layout.calculate_buffers_width()
+  local tabpages_width = Layout.calculate_tabpages_width()
+
+  local buffers_width = available_width - tabpages_width
+  local remaining_width = max(0, buffers_width - used_width)
+  local remaining_width_per_buffer = floor(remaining_width / #base_widths)
+  local remaining_padding_per_buffer = floor(remaining_width_per_buffer / SIDES_OF_BUFFER)
+  local padding_width = max(config.options.minimum_padding, min(remaining_padding_per_buffer, config.options.maximum_padding))
+  local actual_width = used_width + (#base_widths * padding_width * SIDES_OF_BUFFER)
+
+  return {
+    actual_width = actual_width,
+    base_widths = base_widths,
+    buffers_width = buffers_width,
+    padding_width = padding_width,
+    scroll_max = max(0, actual_width - buffers_width),
+    tabpages_width = tabpages_width,
+    used_width = used_width,
+  }
 end
 
 --- @param bufnr integer the buffer to calculate the width of
 --- @param index integer the buffer's numerical index
 --- @return integer width
 function Layout.calculate_buffer_width(bufnr, index)
+  local buffer_activity = Buffer.activities[Buffer.get_activity(bufnr)]
   local buffer_data = state.get_buffer_data(bufnr)
   local buffer_name = buffer_data.name or '[no name]'
-  local width
 
   local icons_option = state.icons(bufnr, Buffer.activities[Buffer.get_activity(bufnr)])
 
-  width = strwidth(icons_option.separator.left) + strwidth(buffer_name) -- separator + name
+  local width = strwidth(icons_option.separator.left) + strwidth(buffer_name) -- separator + name
 
   if icons_option.buffer_index then
-    width = width + #tostring(index) + 1 -- buffer-index + space after buffer-index
+    width = width + #tostring(index) + SPACE_LEN
   elseif icons_option.buffer_number then
-    width = width + #tostring(bufnr) + 1 -- buffer-number + space after buffer-index
+    width = width + #tostring(bufnr) + SPACE_LEN
   end
 
   if icons_option.filetype.enabled then
     --- @diagnostic disable-next-line:param-type-mismatch
     local file_icon = icons.get_icon(bufnr, '')
-    width = width + strwidth(file_icon) + 1 -- icon + space after icon
+    width = width + strwidth(file_icon) + SPACE_LEN
   end
 
   Buffer.for_each_counted_enabled_diagnostic(bufnr, icons_option.diagnostics, function(c, d, _)
     width = width + 1 + strwidth(d.icon) + #tostring(c) -- space before icon + icon + diagnostic count
   end)
 
-  -- close-or-pin-or-save-icon + the space after + right separator
-  width = width + strwidth(icons_option.button or '') + 1 + strwidth(icons_option.separator.right)
+  width = width + strwidth(icons_option.button or '') + SPACE_LEN + strwidth(icons_option.separator.right)
 
-  return width or 0
+  return width
+end
+
+--- @return {[integer]: integer} position_by_bufnr
+function Layout.calculate_buffers_position_by_buffer_number()
+  local current_position = 0
+  local layout = Layout.calculate()
+  local positions = {}
+
+  for i, buffer_number in ipairs(Layout.buffers) do
+    positions[buffer_number] = current_position
+    local width = layout.base_widths[i] + (2 * layout.padding_width)
+    current_position = current_position + width
+  end
+
+  return positions
 end
 
 --- Calculate the width of the buffers
@@ -95,51 +130,20 @@ function Layout.calculate_buffers_width()
   return sum, widths
 end
 
---- Calculate the current layout of the bufferline.
---- @return barbar.layout.data
-function Layout.calculate()
-  local available_width = get_option'columns'
-  available_width = available_width - state.offset.left.width - state.offset.right.width
-
-  local used_width, base_widths = Layout.calculate_buffers_width()
-  local tabpages_width = Layout.calculate_tabpages_width()
-
-  local buffers_width = available_width - tabpages_width
-
-  local remaining_width = max(buffers_width - used_width, 0)
-  local remaining_width_per_buffer = floor(remaining_width / #base_widths)
-  -- PERF: faster than `floor(remaining_width_per_buffer / SIDES_OF_BUFFER)`.
-  --       if `SIDES_OF_BUFFER` changes, this will have to go back to `floor`.
-  local remaining_padding_per_buffer = rshift(remaining_width_per_buffer, 1)
-  local padding_width = max(config.options.minimum_padding, min(remaining_padding_per_buffer, config.options.maximum_padding))
-  local actual_width = used_width + (#base_widths * padding_width * SIDES_OF_BUFFER)
-
-  return {
-    actual_width = actual_width,
-    available_width = available_width,
-    base_widths = base_widths,
-    buffers_width = buffers_width,
-    padding_width = padding_width,
-    tabpages_width = tabpages_width,
-    used_width = used_width,
-  }
-end
-
---- @return {[integer]: integer} position_by_bufnr
-function Layout.calculate_buffers_position_by_buffer_number()
-  local current_position = 0
-  local layout = Layout.calculate()
-  local positions = {}
-
-  for i, buffer_number in ipairs(Layout.buffers) do
-    positions[buffer_number] = current_position
-    local width = layout.base_widths[i] + (2 * layout.padding_width)
-    current_position = current_position + width
+--- The number of characters needed to represent the tabpages.
+--- @return integer width
+function Layout.calculate_tabpages_width()
+  if not config.options.tabpages then
+    return 0
   end
 
-  return positions
+  local total_tabpages = tabpagenr('$')
+  return total_tabpages > 1 and
+    SPACE_LEN + #tostring(tabpagenr()) + SLASH_LEN + #tostring(total_tabpages) + SPACE_LEN or
+    0
 end
 
+--- Determines what the width of a buffer would be with its padding
 --- @param base_width integer
 --- @param padding_width integer
 --- @return integer width

--- a/lua/barbar/layout.lua
+++ b/lua/barbar/layout.lua
@@ -89,8 +89,8 @@ function Layout.calculate_buffer_width(bufnr, index)
     width = width + strwidth(file_icon) + SPACE_LEN
   end
 
-  Buffer.for_each_counted_enabled_diagnostic(bufnr, icons_option.diagnostics, function(c, d, _)
-    width = width + 1 + strwidth(d.icon) + #tostring(c) -- space before icon + icon + diagnostic count
+  Buffer.for_each_counted_enabled_diagnostic(bufnr, icons_option.diagnostics, function(count, _, option)
+    width = width + SPACE_LEN + strwidth(option.icon) + #tostring(count)
   end)
 
   width = width + strwidth(icons_option.button or '') + SPACE_LEN + strwidth(icons_option.separator.right)

--- a/lua/barbar/layout.lua
+++ b/lua/barbar/layout.lua
@@ -140,7 +140,7 @@ function Layout.calculate_buffers_width()
 
   for i, bufnr in ipairs(Layout.buffers) do
     local width = Layout.calculate_buffer_width(bufnr, i)
-    if state.get_buffer_data(bufnr).pinned then
+    if state.is_pinned(bufnr) then
       pinned_count = pinned_count + 1
       pinned_sum = pinned_sum + width
     else

--- a/lua/barbar/layout.lua
+++ b/lua/barbar/layout.lua
@@ -73,29 +73,42 @@ function Layout.calculate_buffer_width(bufnr, index)
   local buffer_data = state.get_buffer_data(bufnr)
   local buffer_name = buffer_data.name or '[no name]'
 
-  local icons_option = state.icons(bufnr, Buffer.activities[Buffer.get_activity(bufnr)])
+  local icons_option = state.icons(bufnr, buffer_activity)
 
-  local width = strwidth(icons_option.separator.left) + strwidth(buffer_name) -- separator + name
+  local width = strwidth(icons_option.separator.left)
+
+  local filename_enabled = icons_option.filename
+  if filename_enabled then
+    width = width + strwidth(buffer_name)
+  end
 
   if icons_option.buffer_index then
     width = width + #tostring(index) + SPACE_LEN
-  elseif icons_option.buffer_number then
+  end
+
+  if icons_option.buffer_number then
     width = width + #tostring(bufnr) + SPACE_LEN
   end
 
   if icons_option.filetype.enabled then
-    --- @diagnostic disable-next-line:param-type-mismatch
-    local file_icon = icons.get_icon(bufnr, '')
-    width = width + strwidth(file_icon) + SPACE_LEN
+    local file_icon = icons.get_icon(bufnr, buffer_activity)
+    width = width + strwidth(file_icon)
+
+    if filename_enabled then
+      width = width + SPACE_LEN
+    end
   end
 
   Buffer.for_each_counted_enabled_diagnostic(bufnr, icons_option.diagnostics, function(count, _, option)
     width = width + SPACE_LEN + strwidth(option.icon) + #tostring(count)
   end)
 
-  width = width + strwidth(icons_option.button or '') + SPACE_LEN + strwidth(icons_option.separator.right)
+  local button = icons_option.button
+  if button then
+    width = width + strwidth(button) + SPACE_LEN
+  end
 
-  return width
+  return width + strwidth(icons_option.separator.right)
 end
 
 --- @return {[integer]: integer} position_by_bufnr

--- a/lua/barbar/layout.lua
+++ b/lua/barbar/layout.lua
@@ -106,7 +106,7 @@ function Layout.calculate_buffer_width(bufnr, index)
   end)
 
   local button = icons_option.button
-  if button then
+  if button and #button > 0 then
     width = width + strwidth(button) + SPACE_LEN
   end
 

--- a/lua/barbar/layout.lua
+++ b/lua/barbar/layout.lua
@@ -7,6 +7,7 @@ local max = math.max
 local min = math.min
 local table_insert = table.insert
 
+local buf_get_option = vim.api.nvim_buf_get_option --- @type function
 local get_option = vim.api.nvim_get_option --- @type function
 local strwidth = vim.api.nvim_strwidth --- @type function
 local tabpagenr = vim.fn.tabpagenr --- @type function
@@ -74,7 +75,7 @@ function Layout.calculate_buffer_width(bufnr, index)
   local buffer_data = state.get_buffer_data(bufnr)
   local buffer_name = buffer_data.name or '[no name]'
 
-  local icons_option = state.icons(bufnr, buffer_activity)
+  local icons_option = Buffer.get_icons(buffer_activity, buf_get_option(bufnr, 'modified'), buffer_data.pinned)
 
   local width = strwidth(icons_option.separator.left)
 

--- a/lua/barbar/render.lua
+++ b/lua/barbar/render.lua
@@ -568,7 +568,7 @@ local function get_bufferline_group_clumps(layout, bufnrs, refocus)
     local button = {hl = buffer_hl, text = ''}
 
     local button_icon = icons_option.button
-    if button_icon and #button_icon > 1 then
+    if button_icon and #button_icon > 0 then
       button.text = button_icon .. ' '
 
       if click_enabled then

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -42,7 +42,7 @@ local function icons_option_prioritize(higher, lower)
           higher.diagnostics = {}
         end
 
-        for i in ipairs(severity) do
+        for i = 1, #severity do
           higher.diagnostics[i] = utils.setfallbacktable(higher.diagnostics[i], lower_diagnostics[i])
         end
       end

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -17,7 +17,6 @@ local json_decode = vim.json.decode --- @type function
 local deepcopy = vim.deepcopy
 local get_current_buf = vim.api.nvim_get_current_buf --- @type function
 local list_bufs = vim.api.nvim_list_bufs --- @type function
-local list_extend = vim.list_extend
 local list_slice = vim.list_slice
 local severity = vim.diagnostic.severity --- @type {[integer]: string, [string]: integer}
 local tbl_contains = vim.tbl_contains
@@ -159,18 +158,17 @@ end
 --- Sort the pinned tabs to the left of the bufferline.
 --- @return nil
 function state.sort_pins_to_left()
-  local unpinned = {}
+  local pinned = 0
 
-  local i = 1
-  while i <= #state.buffers do
+  local i = #state.buffers
+  while i >= 1 + pinned do
     if state.is_pinned(state.buffers[i]) then
-      i = i + 1
+      table_insert(state.buffers, 1, table_remove(state.buffers, i))
+      pinned = pinned + 1
     else
-      table_insert(unpinned, table_remove(state.buffers, i))
+      i = i - 1
     end
   end
-
-  state.buffers = list_extend(state.buffers, unpinned)
 end
 
 --- Toggle the `bufnr`'s "pin" state.

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -75,10 +75,10 @@ end
 --- @field closing boolean whether the buffer is being closed
 --- @field name? string the name of the buffer
 --- @field position? integer the absolute position of the buffer
---- @field computed_width? integer the width of the buffer + invisible characters
 --- @field computed_position? integer the position of the buffer
+--- @field computed_width? integer the width of the buffer plus invisible characters
 --- @field pinned boolean whether the buffer is pinned
---- @field width? integer the width of the buffer - invisible characters
+--- @field width? integer the width of the buffer minus invisible characters
 
 --- @class barbar.state.offset.side
 --- @field hl? string the highlight group to use
@@ -397,12 +397,10 @@ function state.load_recently_closed()
     return
   end
 
-  pcall(function()
-    local saved_state = json_decode(content, { luanil = { array = true, object = true } })
-    if saved_state.recently_closed ~= nil then
-      state.recently_closed = saved_state.recently_closed
-    end
-  end)
+  local ok, result = pcall(json_decode, content, {luanil = {array = true, object = true}})
+  if ok and result.recently_closed ~= nil then
+    state.recently_closed = result.recently_closed
+  end
 end
 
 -- Exports

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -136,10 +136,10 @@ function state.get_buffer_list()
 
   for _, bufnr in ipairs(list_bufs()) do
     if buf_get_option(bufnr, 'buflisted') and
-      not utils.has(exclude_ft, buf_get_option(bufnr, 'filetype'))
+      not tbl_contains(exclude_ft, buf_get_option(bufnr, 'filetype'))
     then
       local name = buf_get_name(bufnr)
-      if not utils.has(exclude_name, utils.basename(name, hide_extensions)) then
+      if not tbl_contains(exclude_name, utils.basename(name, hide_extensions)) then
         table_insert(result, bufnr)
       end
     end

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -149,6 +149,7 @@ end
 
 -- Pinned buffers
 
+--- PERF: only call this method if you don't already `state.get_buffer_data`
 --- @param bufnr integer
 --- @return boolean pinned `true` if `bufnr` is pinned
 function state.is_pinned(bufnr)
@@ -337,7 +338,7 @@ function state.icons(bufnr, activity)
     icons_option_prioritize_state'modified'
   end
 
-  if state.get_buffer_data(bufnr).pinned then
+  if state.is_pinned(bufnr) then
     icons_option_prioritize_state'pinned'
   end
 

--- a/lua/barbar/utils.lua
+++ b/lua/barbar/utils.lua
@@ -137,15 +137,6 @@ local utils = {
       notify_once_util(name .. ' is deprecated. Use ' .. alternative .. 'instead.', vim.log.levels.WARN)
     end,
 
-  --- Return whether element `n` is in a `list.
-  --- @generic T
-  --- @param list T[]
-  --- @param t T
-  --- @return boolean
-  has = function(list, t)
-    return index_of(list, t) ~= nil
-  end,
-
   --- utilities for working with highlight groups.
   --- @class barbar.utils.hl
   hl = {


### PR DESCRIPTION
Pinned buffers now always stay visible in the bufferline. Additionally, they take up less space— they use the minimum padding, and no longer show a filename or pin icon by default. 

To restore the old pinned buffer look, do:

```lua
require'barbar'.setup {
  icons = {
    pinned = {
      button = '',
      filename = true,
      separator = {right = ''},
    },
  },
}
```

Todo:

* [x] Minimal default pinned buffer look ![cap](https://user-images.githubusercontent.com/36409591/229316651-e6970912-07c5-457c-8a0b-ada6a405bd4f.png)
* [x] Always show pinned tabs

---

Closes #393.
Closes #401.