### PR TITLE
feat: add number styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ require'barbar'.setup {
 
   icons = {
     -- Configure the base icons on the bufferline.
+    -- Valid options to display the buffer index and -number are `true`, 'superscript' and 'subscript'
     buffer_index = false,
     buffer_number = false,
     button = '',

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -232,13 +232,13 @@ icons ~
 
                                              *barbar-setup.icons.buffer_index*
   icons.buffer_index ~
-    `boolean`  (default: `false`)
+    `boolean|'superscript'|'subscript'`  (default: `false`)
     if `true`, show the index of the buffer with respect to the ordering of
     the buffers in the tabline.
 
                                             *barbar-setup.icons.buffer_number*
   icons.buffer_number ~
-    `boolean`  (default: `false`)
+    `boolean|'superscript'|'subscript'`  (default: `false`)
     If `true`, show the `bufnr` for the associated buffer.
 
                                                    *barbar-setup.icons.button*

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -52,7 +52,11 @@ local function tbl_deep_extend_diagnostic_icons(icons)
   end
 end
 
---- @alias barbar.config.options.icons.git.statuses 'added'|'changed'|'deleted'
+--- @class barbar.config.options.icons.buffer.filetype
+--- @field custom_colors? boolean if present, this color will be used for ALL filetype icons
+--- @field enabled boolean iff `true`, show the `devicons` for the associated buffer's `filetype`.
+
+--- @alias barbar.config.options.icons.buffer.git.statuses 'added'|'changed'|'deleted'
 local GIT_STATUSES = {'added', 'changed', 'deleted'}
 
 --- @class barbar.config.options.icons.buffer.git.status
@@ -60,23 +64,17 @@ local GIT_STATUSES = {'added', 'changed', 'deleted'}
 --- @field icon string
 
 --- @class barbar.config.options.icons.buffer.git
---- @field [barbar.config.options.icons.git.statuses] barbar.config.options.icons.buffer.git.status
+--- @field [barbar.config.options.icons.buffer.git.statuses] barbar.config.options.icons.buffer.git.status
 
---- @class barbar.config.options.icons.buffer.filetype
---- @field custom_colors? boolean if present, this color will be used for ALL filetype icons
---- @field enabled boolean iff `true`, show the `devicons` for the associated buffer's `filetype`.
+--- @alias barbar.config.options.icons.buffer.number boolean|'superscript'|'subscript'
 
 --- @class barbar.config.options.icons.buffer.separator
 --- @field left string a buffer's left separator
 --- @field right string a buffer's right separator
 
---- @class barbar.config.options.icons.scroll
---- @field left string
---- @field right string
-
 --- @class barbar.config.options.icons.buffer
---- @field buffer_index boolean iff `true`, show the index of the associated buffer with respect to the ordering of the buffers in the tabline.
---- @field buffer_number boolean iff `true`, show the `bufnr` for the associated buffer.
+--- @field buffer_index barbar.config.options.icons.buffer.number iff `true`|`'superscript'`|`'subscript'`, show the index of the associated buffer with respect to the ordering of the buffers in the tabline.
+--- @field buffer_number barbar.config.options.icons.buffer.number iff `true`|`'superscript'`|`'subscript'`, show the `bufnr` for the associated buffer.
 --- @field button false|string the button which is clicked to close / save a buffer, or indicate that it is pinned.
 --- @field diagnostics barbar.config.options.icons.buffer.diagnostics the diagnostic icons
 --- @field filename boolean iff `true`, show the filename
@@ -87,6 +85,10 @@ local GIT_STATUSES = {'added', 'changed', 'deleted'}
 --- @class barbar.config.options.icons.state: barbar.config.options.icons.buffer
 --- @field modified barbar.config.options.icons.buffer the icons used for an modified buffer
 --- @field pinned barbar.config.options.icons.buffer the icons used for a pinned buffer
+
+--- @class barbar.config.options.icons.scroll
+--- @field left string
+--- @field right string
 
 --- @class barbar.config.options.icons: barbar.config.options.icons.state
 --- @field alternate barbar.config.options.icons.state the icons used for an alternate buffer

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -42,7 +42,7 @@ local WARN = severity.WARN
 --- @field computed_position? integer the real position of the buffer
 --- @field computed_width? integer the width of the buffer plus invisible characters
 --- @field diagnostics? {[DiagnosticSeverity]: integer}
---- @field gitsigns? {[barbar.config.options.icons.git.statuses]: integer} the real position of the buffer
+--- @field gitsigns? {[barbar.config.options.icons.buffer.git.statuses]: integer} the real position of the buffer
 --- @field name? string the name of the buffer
 --- @field pinned boolean whether the buffer is pinned
 --- @field position? integer the absolute position of the buffer

--- a/lua/barbar/ui/render.lua
+++ b/lua/barbar/ui/render.lua
@@ -39,9 +39,25 @@ local nodes = require('barbar.ui.nodes')
 local notify = require('barbar.utils').notify
 local state = require('barbar.state')
 
+-- Digits for optional styling of buffer_number and buffer_index.
+local SUPERSCRIPT_DIGITS = { '⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹' }
+local SUBSCRIPT_DIGITS = { '₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉' }
+
 --- Last value for tabline
 --- @type string
 local last_tabline = ''
+
+--- @param num number
+--- @param style barbar.config.options.icons.buffer.number
+--- @return integer|string styled, integer substituted
+local function style_number(num, style)
+  if style == true then
+    return num, 0
+  end
+
+  local digits = style == 'subscript' and SUBSCRIPT_DIGITS or SUPERSCRIPT_DIGITS
+  return tostring(num):gsub('%d', function(match) return digits[match + 1] end)
+end
 
 --- Create valid `&tabline` syntax which highlights the next item in the tabline with the highlight `group` specified.
 --- @param group string
@@ -425,7 +441,7 @@ local function get_bufferline_containers(data, bufnrs, refocus)
     local buffer_index = { hl = '', text = '' }
     if icons_option.buffer_index then
       buffer_index.hl = wrap_hl('Buffer' .. activity_name .. 'Index')
-      buffer_index.text = i .. ' '
+      buffer_index.text = style_number(i, icons_option.buffer_index) .. ' '
     end
 
     --- The buffer number
@@ -433,7 +449,7 @@ local function get_bufferline_containers(data, bufnrs, refocus)
     local buffer_number = { hl = '', text = '' }
     if icons_option.buffer_number then
       buffer_number.hl = wrap_hl('Buffer' .. activity_name .. 'Number')
-      buffer_number.text = bufnr .. ' '
+      buffer_number.text = style_number(bufnr, icons_option.buffer_number) .. ' '
     end
 
     --- The close icon


### PR DESCRIPTION
Thanks for the maintenance. It's nice to see the repositories active development.

This PR extends the options for buffer indices and numbers with the style options `'superscript'` and `'subscript'`. Current boolean values will continue to work as they are. 
I did my best to follow the conventions I've seen in the repo.