### PR TITLE
feat: improve offset truncation

### DIFF
--- a/lua/barbar/buffer.lua
+++ b/lua/barbar/buffer.lua
@@ -26,6 +26,9 @@ local WARN = vim.diagnostic.severity.WARN --- @type integer
 local config = require'barbar.config'
 local utils = require'barbar.utils'
 
+local ELLIPSIS = '…'
+local ELLIPSIS_LEN = strwidth(ELLIPSIS)
+
 --- @alias barbar.buffer.activity 1|2|3|4
 
 --- @alias barbar.buffer.activity.name 'Inactive'|'Alternate'|'Visible'|'Current'
@@ -122,15 +125,14 @@ local buffer = {
       name = '[buffer ' .. buffer_number .. ']'
     end
 
-    local ellipsis = '…'
     if strwidth(name) > maximum_length then
       local ext_index = name:reverse():find('%.')
 
-      if ext_index ~= nil and (ext_index < maximum_length - #ellipsis) then
+      if ext_index ~= nil and (ext_index < maximum_length - ELLIPSIS_LEN) then
         local extension = name:sub(-ext_index)
-        name = strcharpart(name, 0, maximum_length - #ellipsis - #extension) .. ellipsis .. extension
+        name = strcharpart(name, 0, maximum_length - ELLIPSIS_LEN - #extension) .. ELLIPSIS .. extension
       else
-        name = strcharpart(name, 0, maximum_length - #ellipsis) .. ellipsis
+        name = strcharpart(name, 0, maximum_length - ELLIPSIS_LEN) .. ELLIPSIS
       end
 
       -- safety to prevent recursion in any future edge case

--- a/lua/barbar/render.lua
+++ b/lua/barbar/render.lua
@@ -139,6 +139,9 @@ local function hl_tabline(group)
   return '%#' .. group .. '#'
 end
 
+local ELLIPSIS = '…'
+local ELLIPSIS_LEN = strwidth(ELLIPSIS)
+
 --- Select from `groups` while fitting within the provided `width`, discarding all indices larger than the last index that fits.
 --- @param groups barbar.render.group[]
 --- @param width integer
@@ -152,10 +155,9 @@ local function slice_groups_right(groups, width)
     local text_width = strwidth(group.text)
     accumulated_width = accumulated_width + text_width
 
-    local ellipsis = '…'
     if accumulated_width >= width then
-      local diff = text_width - (accumulated_width - width) - strwidth(ellipsis) + 2
-      local new_group = {hl = group.hl, text = strcharpart(group.text, 0, diff) .. ellipsis}
+      local diff = text_width - (accumulated_width - width) - ELLIPSIS_LEN + 2
+      local new_group = {hl = group.hl, text = strcharpart(group.text, 0, diff) .. ELLIPSIS}
       table_insert(new_groups, new_group)
       break
     end

--- a/lua/barbar/render.lua
+++ b/lua/barbar/render.lua
@@ -152,9 +152,10 @@ local function slice_groups_right(groups, width)
     local text_width = strwidth(group.text)
     accumulated_width = accumulated_width + text_width
 
+    local ellipsis = '…'
     if accumulated_width >= width then
-      local diff = text_width - (accumulated_width - width)
-      local new_group = {hl = group.hl, text = strcharpart(group.text, 0, diff)}
+      local diff = text_width - (accumulated_width - width) - strwidth(ellipsis) + 2
+      local new_group = {hl = group.hl, text = strcharpart(group.text, 0, diff) .. ellipsis}
       table_insert(new_groups, new_group)
       break
     end


### PR DESCRIPTION
I hoped tuning the offset truncation might fit as a followup to #414 

Truncated text get a bit shifted. The reason for this is afaik found on:
https://github.com/tobealive/barbar.nvim/blob/f31c82d6667f503de558b033006f1426ee169dc7/lua/barbar/render.lua#L677

Adding `+ 2` removes the shift. Since it's nice to give a visual clue when text gets truncated, I added the ellipsis character. I followed the assignment to a variable, which was done in another place. But it's called just twice here, so please let me if you prefer to have it changed.

![Screenshot_20230402_042800](https://user-images.githubusercontent.com/34311583/229328031-9a93b445-531e-43e6-9618-8c9271085e26.png)

![Screenshot_20230402_042843](https://user-images.githubusercontent.com/34311583/229328037-3ac40e2f-fac1-4754-9cf1-e2466649e970.png)
