### PR TITLE
chore: editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = false
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = tab
+indent_style = space
+insert_final_newline = false
+tab_width = 2
+trim_trailing_whitespace = true
+
+[barbar.txt]
+max_line_length = 78
+
+[*.{lua}]
+max_line_length = 100

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -444,4 +444,4 @@ tabpages ~
 ==============================================================================
 5. Integrations                                          *barbar-integrations*
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=2:ft=help:norl:


### PR DESCRIPTION
This adds an editorconfig, which is supported natively by Neovim 0.9. It automatically sets options that this repo uses.

We can potentially extend it in the future to create inline diagnostics when double quotes are used, etc.

Closes #411 