### PR TITLE
fix doc

### DIFF
--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -244,7 +244,7 @@ icons ~
        Enable showing diagnostics of this |diagnostic-severity| in the
        'tabline'.
 
-                                      *barbar-setup.icons.diagnostics.enabled*
+                                      *barbar-setup.icons.diagnostics.icon*
      icons.diagnostics.icon ~
        `boolean`  (defaults: `'Ⓧ '`, `'💡'`, `'ⓘ '`, and `'⚠️ '`)
        The icon which accompanies the number of diagnostics.


### PR DESCRIPTION
Fixes:

```
    ● barbar.nvim 7.32ms   core.autocmds
        ...hare/nvim/lazy/lazy.nvim/lua/lazy/manage/task/plugin.lua:51: Vim:E154: Marcador duplicado "barbar-setup.icons.diagnostics.enabled" no arquivo /Users/otavio/.local/share/nvim/lazy/barbar.nvim/doc//barbar.txt
```

on lazy