### PR TITLE
fix: typo custom_color -> custom_colors

### DIFF
--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -31,7 +31,7 @@ local DEFAULT_DIAGNOSTIC_ICONS = {
 }
 
 --- @class barbar.config.options.icons.filetype
---- @field custom_color? boolean if present, this color will be used for ALL filetype icons
+--- @field custom_colors? boolean if present, this color will be used for ALL filetype icons
 --- @field enabled? boolean iff `true`, show the `devicons` for the associated buffer's `filetype`.
 
 --- @class barbar.config.options.icons.separator

--- a/lua/barbar/render.lua
+++ b/lua/barbar/render.lua
@@ -592,7 +592,7 @@ local function get_bufferline_items(layout, bufnrs, refocus)
         and 'BufferInactive'
         or iconHl
 
-      icon.hl = icons_option.filetype.custom_color and
+      icon.hl = icons_option.filetype.custom_colors and
         hl_tabline('Buffer' .. activity .. 'Icon') or
         (hlName and hl_tabline(hlName) or buffer_hl)
       icon.text = iconChar .. ' '


### PR DESCRIPTION
The `custom_colors` option is not named consistently.
Indeed, I was able to find two mentions of `custom_color` which I suppose are typos.