### PR TITLE
feat: disable auto-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ files you can even type the letter ahead from memory.
 require('lazy').setup {
   {'romgrk/barbar.nvim',
     dependencies = 'nvim-tree/nvim-web-devicons',
+    init = function() vim.g.barbar_auto_setup = false end,
     opts = {
-      -- lazy.nvim can automatically call setup for you. just put your options here:
-      -- insert_at_start = true,
+      -- lazy.nvim will automatically call setup for you. put your options here, anything missing will use the default:
       -- animation = true,
-      -- …etc
+      -- insert_at_start = true,
+      -- …etc.
     },
     version = '^1.0.0', -- optional: only update when a new 1.x version is released
   },
@@ -61,7 +62,8 @@ You can skip the dependency on `'nvim-tree/nvim-web-devicons'` if you
 install [nerd fonts](https://www.nerdfonts.com/).
 
 ##### Requirements
- - Neovim `0.7`
+
+- Neovim `0.7`
 
 ## Features
 
@@ -235,14 +237,15 @@ map('n', '<Space>bw', '<Cmd>BufferOrderByWindowNumber<CR>', opts)
 > If you're using Vim Script, just wrap `setup` like this:
 >
 > ```vim
+> let g:barbar_auto_setup = v:false " disable auto-setup
 > lua << EOF
-> require'barbar'.setup {…}
+>   require'barbar'.setup {…}
 > EOF
 > ```
 
 ```lua
--- Set barbar's options
-require'barbar'.setup {
+vim.g.barbar_auto_setup = false -- disable auto-setup
+require'barbar'.setup { -- Set barbar's options
   -- Enable/disable animations
   animation = true,
 

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -110,10 +110,20 @@ Highlight groups are created in this way: `Buffer<STATUS><PART>`.
 ==============================================================================
 4. Settings                                                     *barbar-setup*
 
+*g:barbar_auto_setup*  `boolean`  (default: `true`)
+  By default, |barbar.nvim| will call the |barbar.setup()| function for you.
+  However, if you want to customize this plugin, there is no need for that
+  since you will have to call |barbar.setup()| yourself.
+
+  To disable the auto-setup, set this variable to `false`: >
+    vim.g.barbar_auto_setup = false -- Lua
+    let g:barbar_auto_setup = v:false " Vim script
+<
+
 `barbar`.setup({options})                                       *barbar.setup()*
 
-  To configure barbar or enable it for the first time, you must call this
-  `setup` function. The valid {options} are listed below.
+  To configure barbar, you must call this `setup` function. The valid
+  {options} are listed below.
 
   Lua example: >
     require'barbar'.setup {

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -132,16 +132,12 @@ local DEPRECATED_OPTIONS = {
 --- @field tabpages boolean
 
 --- @class barbar.config
---- @field did_initialize boolean
 --- @field options barbar.config.options
-local config = {
-  did_initialize = false,
-  options = {},
-}
+local config = { options = {} }
 
 --- @param options? table
 function config.setup(options)
-  config.did_initialize = true
+  vim.g.barbar_auto_setup = false
 
   if type(options) ~= 'table' then
     options = {}

--- a/plugin/barbar.lua
+++ b/plugin/barbar.lua
@@ -4,16 +4,16 @@
 -- Date: Fri 22 May 2020 02:22:36 AM EDT
 -- !::exe [So]
 
-local user_config = vim.g.bufferline
+if vim.g.barbar_auto_setup ~= false then
+  local options = vim.g.bufferline
 
-if user_config then
-  require'barbar.utils'.notify_once(
-    "`g:bufferline` is deprecated, use `require'barbar'.setup` instead. " ..
-      'See `:h barbar-setup` for more information.',
-    vim.log.levels.WARN
-  )
-end
+  if options then
+    require'barbar.utils'.notify_once(
+      "`g:bufferline` is deprecated, use `require'barbar'.setup` instead. " ..
+        'See `:h barbar-setup` for more information.',
+      vim.log.levels.WARN
+    )
+  end
 
-if require'barbar.config'.did_initialize == false then
-  require'bufferline'.setup(user_config)
+  require'barbar'.setup(options)
 end


### PR DESCRIPTION
Enables users to disable the auto-setup in `plugin/barbar.lua`. All you have to do is:

```lua
vim.g.barbar_auto_setup = false
```

```vim
let g:barbar_auto_setup = v:false
```

---

Closes #431