### PR TITLE
fix(buffer): buffer name cut off at `<e2>`

### DIFF
--- a/lua/barbar/buffer.lua
+++ b/lua/barbar/buffer.lua
@@ -149,9 +149,6 @@ local buffer = {
       else
         name = strcharpart(name, 0, maximum_length - ELLIPSIS_LEN) .. ELLIPSIS
       end
-
-      -- safety to prevent recursion in any future edge case
-      name = name:sub(1, maximum_length)
     end
 
     return name


### PR DESCRIPTION
Closes #447.