### PR TITLE
fix: close click confirmation message reports error

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -30,6 +30,9 @@ local render = require'barbar.render'
 local state = require'barbar.state'
 local utils = require'barbar.utils'
 
+--- The `<mods>` used for the close click handler
+local CLOSE_CLICK_MODS = vim.api.nvim_cmd and {confirm = true} or 'confirm'
+
 --- Whether barbar is currently set up to render.
 local enabled = false
 
@@ -57,7 +60,7 @@ function events.close_click_handler(buffer)
     buf_call(buffer, function() command('w') end)
     exec_autocmds('BufModifiedSet', {buffer = buffer})
   else
-    bbye.bdelete(false, buffer)
+    bbye.bdelete(false, buffer, CLOSE_CLICK_MODS)
   end
 end
 

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -31,7 +31,7 @@ local state = require'barbar.state'
 local utils = require'barbar.utils'
 
 --- The `<mods>` used for the close click handler
-local CLOSE_CLICK_MODS = vim.api.nvim_cmd and {confirm = true} or 'confirm'
+local CLOSE_CLICK_MODS = vim.api.nvim_cmd and { confirm = true } or 'confirm'
 
 --- Whether barbar is currently set up to render.
 local enabled = false


### PR DESCRIPTION
Certain buffers show a message when trying to close them (e.g. `:terminal`s) if you do not `:confirm` their closure. This was getting picked up by the `bbye` (since it is not a `v:errmsg`).

To fix it, I have switched from using `v:errmsg` to the `pcall`'s `result` return value.

However, if we left it at that, it would be impossible to click to close certain windows (since they need `:confirm`). Thus I have added `:confirm` as a modifier to the close click handler.

---

Closes #449.