### PR TITLE
fix(config): default `button` not visible on NerdFonts 3

### DIFF
--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -242,7 +242,7 @@ function config.setup(options)
   local default_icons = {
     buffer_index = false,
     buffer_number = false,
-    button = '',
+    button = '𝝬',
     diagnostics = {},
     gitsigns = {
       added = { enabled = false, icon = '+' },


### PR DESCRIPTION
NerdFonts released 3.0 recently, which removed a ton of deprecated icons which were in outside of the private use unicode area. Our buttons turned into other symbols this morning for a subset of users

Instead of using another nerdfont icon, I went with the convention we've been following to use unicode characters as defaults. We can always provide a preset to use nerdfont icons when presets are launched.