### PR TITLE
docs: table of contents reference

### DIFF
--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -9,7 +9,7 @@ Help on barbar.nvim                                        *barbar* *barbar.nvim
 1. Intro                        |barbar-intro|
 2. Mappings & Commands          |barbar-mappings| |barbar-commands|
 3. Highlights                   |barbar-highlights|
-4. Settings                     |barbar-settings|
+4. Settings                     |barbar-setup|
 5. Integrations                 |barbar-integrations|
 
 ==============================================================================


### PR DESCRIPTION
Noticed a missing reference when looking through help files, here is a small pr