### PR TITLE
feat: `focus_on_close = 'previous'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ require'barbar'.setup {
   exclude_name = {'package.json'},
 
   -- A buffer to this direction will be focused (if it exists) when closing the current buffer.
-  -- Valid options are 'left' (the default) and 'right'
+  -- Valid options are 'left' (the default), 'previous', and 'right'
   focus_on_close = 'left',
 
   -- Hide inactive buffers and file extensions. Other options are `alternate`, `current`, and `visible`.

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -175,9 +175,13 @@ exclude_name ~
 
                                                  *barbar-setup.focus_on_close*
 focus_on_close ~
-  `'left'|'right'`  (default: `'left'`)
-  A buffer to this direction will be focused (if it exists) when closing the
-  current buffer.
+  `'left'|'previous'|'right'`  (default: `'left'`)
+  The algorithm to use for getting the next buffer after closing the current
+  one:
+
+  - `'left'`: focus the buffer to the left of the current buffer.
+  - `'previous'`: focus the previous buffer.
+  - `'right'`: focus the buffer to the right of the current buffer.
 
                                                            *barbar-setup.hide*
 hide ~

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -155,7 +155,7 @@ local DEPRECATED_OPTIONS = {
 --- @field clickable boolean
 --- @field exclude_ft string[]
 --- @field exclude_name string[]
---- @field focus_on_close side
+--- @field focus_on_close side|'previous'
 --- @field hide barbar.config.options.hide
 --- @field highlight_alternate boolean
 --- @field highlight_inactive_file_icons boolean
@@ -271,7 +271,7 @@ function config.setup(options)
     clickable = true,
     exclude_ft = {},
     exclude_name = {},
-    focus_on_close = 'left',
+    focus_on_close = 'previous',
     hide = {},
     icons = default_icons,
     highlight_alternate = false,


### PR DESCRIPTION
The default is now also `'previous'`, since that is what users of other IDEs would expect.

Closes #465.