### PR TITLE
docs: fix incorrect label for the mini.nvim integration code

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ in the demos above.
 
 ##### mini.nvim
 
-Here is a `persistence.nvim` config which can be used:
+Here is a `mini.sessions` config which can be used:
 
 ```lua
 vim.opt.sessionoptions:append 'globals'


### PR DESCRIPTION
The code for mini.nvim session integration is incorrectly labelled as being for persistence.nvim