### PR TITLE
fix(events.lua): Listen for default and user-configured sidebar_filetype close events

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -213,12 +213,17 @@ function events.enable()
             group = augroup_render,
           })
 
-          create_autocmd(option.event or 'BufWinLeave', {
+          local close_events = { "BufWinLeave" }
+          if not vim.tbl_contains(close_events, option.event) then
+            table.insert(close_events, option.event)
+          end
+
+          create_autocmd(close_events, {
             buffer = tbl.buf,
             callback = function()
               widths[side][ft] = nil
               set_offset(total_widths(side), nil, nil, side)
-              del_autocmd(autocmd)
+              pcall(del_autocmd, autocmd)
             end,
             group = augroup_render,
             once = true,

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -214,7 +214,7 @@ function events.enable()
           })
 
           local close_events = { "BufWinLeave" }
-          if not vim.tbl_contains(close_events, option.event) then
+          if option.event and not close_events[1] ~= option.event  then
             table.insert(close_events, option.event)
           end
 


### PR DESCRIPTION
Creates default `BufWinLeave` autocmd and appends custom `option.event` if it differs from the default. 

Fails silently using `pcall` if the other event already deleted the `autocmd` from line 192.

Closes #502

Tested with "print debugs"
```lua
local ok, _ = pcall(del_autocmd, autocmd)
if not ok then
  print("couldn't delete autocmd", vim.inspect(autocmd), vim.inspect(e))
else
  print("deleted autocmd", vim.inspect(autocmd), vim.inspect(e))
end
```
- [x] Closing with `:q`
![image](https://github.com/romgrk/barbar.nvim/assets/4416345/dbdc7e68-666e-4f02-a339-2820b600c857)

- [x] Toggling
![image](https://github.com/romgrk/barbar.nvim/assets/4416345/b277a141-fcda-4eb3-8743-95397794ca23)

