### PR TITLE
doc: remove invalid comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ require('lazy').setup {
 ```lua
 -- These optional plugins should be loaded directly because of a bug in Packer lazy loading
 use 'nvim-tree/nvim-web-devicons' -- OPTIONAL: for file icons
-use 'lewis6991/gitsigns.nvim', -- OPTIONAL: for git status
+use 'lewis6991/gitsigns.nvim' -- OPTIONAL: for git status
 use 'romgrk/barbar.nvim'
 ```
 


### PR DESCRIPTION
There is a comma in `packer.nvim` in `README.md` installation section, which, when running `:PackerSync`, causes below error:

```
Error detected while processing :source (no file):
E5107: Error loading lua [string ":source (no file)"]:27: unexpected symbol near ','
```
