### PR TITLE
chore(gitignore): ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lua/.luarc.json
+doc/tags


### PR DESCRIPTION
Makes it so `:helptags ALL` does not modify the state of the repo.