### PR TITLE
fix(events): `:term` stays open after job finishes on 0.10-nightly

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -256,6 +256,11 @@ function events.enable()
     group = augroup_render,
   })
 
+  create_autocmd('TermClose', {
+    callback = function() render.update(true) end,
+    group = augroup_render,
+  })
+
   create_autocmd('User', {
     callback = function()
       local relative = require('barbar.fs').relative


### PR DESCRIPTION
From `:h news`:

> Terminal buffers started with no arguments (and use 'shell') close
> automatically if the job exited without error, eliminating the (often
> unwanted) "[Process exited 0]" message.

Closes #522