### PR TITLE
ref: always show pinned buffers, even with `hide`

### DIFF
--- a/lua/barbar/buffer.lua
+++ b/lua/barbar/buffer.lua
@@ -6,7 +6,6 @@ local max = math.max
 local min = math.min
 local rshift = bit.rshift
 local table_concat = table.concat
-local table_insert = table.insert
 
 local buf_get_name = vim.api.nvim_buf_get_name --- @type function
 local buf_get_option = vim.api.nvim_buf_get_option --- @type function
@@ -146,28 +145,6 @@ function buffer.get_unique_name(first, second)
   end
 
   return first_result, second_result
-end
-
---- Filter buffer numbers which are not to be shown during the render process.
---- Does **not** mutate `bufnrs`.
---- @param bufnrs integer[]
---- @return integer[] bufnrs the shown buffers
-function buffer.hide(bufnrs)
-  local hide = config.options.hide
-  if hide.alternate or hide.current or hide.inactive or hide.visible then
-    local shown = {}
-
-    for _, buffer_number in ipairs(bufnrs) do
-      local activity = activities[buffer.get_activity(buffer_number)]
-      if not hide[activity:lower()] then
-        table_insert(shown, buffer_number)
-      end
-    end
-
-    bufnrs = shown
-  end
-
-  return bufnrs
 end
 
 return buffer

--- a/lua/barbar/ui/layout.lua
+++ b/lua/barbar/ui/layout.lua
@@ -190,7 +190,7 @@ end
 --- Calculate the width of the buffers
 --- @return integer pinned_count, integer pinned_sum, integer unpinned_sum, integer[] widths
 function layout.calculate_buffers_width()
-  layout.buffers = buffer.hide(state.buffers)
+  layout.buffers = layout.hide(state.buffers)
 
   local pinned_count = 0
   local pinned_sum = 0
@@ -233,6 +233,27 @@ end
 --- @return integer width
 function layout.calculate_width(base_width, padding_width)
   return base_width + (padding_width * SIDES_OF_BUFFER)
+end
+
+--- Filter buffers which are not to be shown in the layout.
+--- Does **not** mutate `bufnrs`.
+--- @param bufnrs integer[]
+--- @return integer[] shown the shown buffers
+function layout.hide(bufnrs)
+  local hide = config.options.hide
+  if hide.alternate or hide.current or hide.inactive or hide.visible then
+    local shown = {}
+
+    for _, buffer_number in ipairs(bufnrs) do
+      if state.is_pinned(buffer_number) or not hide[buffer.activities[buffer.get_activity(buffer_number)]:lower()] then
+        table_insert(shown, buffer_number)
+      end
+    end
+
+    bufnrs = shown
+  end
+
+  return bufnrs
 end
 
 return layout

--- a/lua/barbar/ui/render.lua
+++ b/lua/barbar/ui/render.lua
@@ -708,7 +708,7 @@ function render.update(update_names, refocus)
     return
   end
 
-  local buffers = buffer.hide(render.get_updated_buffers(update_names))
+  local buffers = layout.hide(render.get_updated_buffers(update_names))
 
   -- Auto hide/show if applicable
   if config.options.auto_hide then


### PR DESCRIPTION
Closes #525

Changes the `hide()` function so that `pinned` buffers are still shown, even if the `hide` config setting would normally apply to them. I figure that hiding a pinned buffer is probably not desired behavior.