### PR TITLE
Customizable `auto_hide` count

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ require'barbar'.setup {
   -- Enable/disable animations
   animation = true,
 
-  -- Enable/disable auto-hiding the tab bar when there is a single buffer
+  -- Automatically hide the tabline when there are this many buffers left.
+  -- Set to any value >=0 to enable.
   auto_hide = false,
 
   -- Enable/disable current/total tabpages indicator (top right corner)

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -129,7 +129,7 @@ Highlight groups are created in this way: `Buffer<STATUS><PART>`.
 
   Lua example: >
     require'barbar'.setup {
-      auto_hide = true,
+      auto_hide = 1,
       clickable = false,
       icons = {current = {filetype = {enabled = false}}},
       maximum_padding = math.huge,
@@ -139,7 +139,7 @@ Highlight groups are created in this way: `Buffer<STATUS><PART>`.
   Vimscript example (see |:lua-heredoc| for more details): >
     lua << EOF
     require'barbar'.setup {
-      auto_hide = true,
+      auto_hide = 1,
       clickable = false,
       icons = {current = {filetype = {enabled = false}}},
       maximum_padding = math.huge,
@@ -153,8 +153,13 @@ animation ~
 
                                                       *barbar-setup.auto_hide*
 auto_hide ~
-  `boolean`  (default: `false`)
-  Enable/disable auto-hiding the tab bar when there is a single buffer.
+  `false|integer`  (default: `-1`)
+  Automatically hide the 'tabline' when there are this many buffers left. Set
+  to any value less than `0` to disable.
+
+  For example: `auto_hide = 0` hides the 'tabline' when there would be zero
+  buffers shown, `auto_hide  = 1` hides the 'tabline' when there would only be
+  one, etc.
 
                                                       *barbar-setup.clickable*
 clickable ~

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -195,7 +195,7 @@ local DEPRECATED_OPTIONS = {
 
 --- @class barbar.config.options
 --- @field animation boolean
---- @field auto_hide boolean
+--- @field auto_hide integer
 --- @field clickable boolean
 --- @field exclude_ft string[]
 --- @field exclude_name string[]
@@ -273,7 +273,14 @@ function config.setup(options)
     options.closable = nil
   end
 
-  do
+  -- convert `auto_hide = true`|`false` to `auto_hide = -1`|`1`
+  if options.auto_hide == false then
+    options.auto_hide = -1
+  elseif options.auto_hide == true then
+    options.auto_hide = 1
+  end
+
+  do -- convert `{Foo = true}` to `{Foo = {event = nil, text = nil}}`
     local sidebar_filetypes = options.sidebar_filetypes
     if sidebar_filetypes then
       for k, v in pairs(sidebar_filetypes) do
@@ -309,7 +316,7 @@ function config.setup(options)
 
   config.options = tbl_deep_extend('keep', options, {
     animation = true,
-    auto_hide = false,
+    auto_hide = -1,
     clickable = true,
     exclude_ft = {},
     exclude_name = {},

--- a/lua/barbar/ui/render.lua
+++ b/lua/barbar/ui/render.lua
@@ -711,8 +711,8 @@ function render.update(update_names, refocus)
   local buffers = layout.hide(render.get_updated_buffers(update_names))
 
   -- Auto hide/show if applicable
-  if config.options.auto_hide then
-    if #buffers + #list_tabpages() < 3 then -- 3 because the condition for auto-hiding is 1 visible buffer and 1 tabpage (2).
+  if config.options.auto_hide > -1 then
+    if #buffers <= config.options.auto_hide and #list_tabpages() < 2 then
       if get_option'showtabline' == 2 then
         set_option('showtabline', 0)
       end


### PR DESCRIPTION
Closes #528 

Users can now specify how many buffers they would like to tolerate before showing the tabline, e.g. `auto_hide = 0` for hiding the tabline when there are zero buffers left. 

The old values, `false` and `true`, have been translated into `-1` and `1` respectively. This is not a breaking change— it happens silently during `setup`.