### PR TITLE
Added a note, for the mapping of Alt key to Option for terminals like…

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ No default mappings are provided, here is an example. It is recommended to use
 the `BufferClose` command to close buffers instead of `bdelete` because it will
 not mess your window layout.
 
+> **Note**
+>
+> In the below key mappings, the Alt key is being used.
+> If you are using a terminal like iTerm on Mac, you
+> will want to make sure that your Option key is properly
+> mapped to Alt. Its under Profiles > Keys, select Esc+
+
 ```vim
 " Move to previous/next
 nnoremap <silent>    <A-,> <Cmd>BufferPrevious<CR>


### PR DESCRIPTION
I had some trouble figuring out how to use the key mappings on iTerm on mac. 
Figured out this is an issue with the Option key not being properly mapped to Alt on given terminals from an old reddit thread.
Generally, from my experience the Option is something rarely used. 

I think a note would serve the users well. Given that Option is not a key mapping really used that often. (At least from my experience) 