### PR TITLE
feat: reorder buffers with mouse drag

### DIFF
--- a/lua/barbar/api.lua
+++ b/lua/barbar/api.lua
@@ -254,7 +254,7 @@ local MOVE_DURATION = 150
 --- @param from_idx integer the buffer's original index.
 --- @param to_idx integer the buffer's new index.
 --- @return nil
-local function move_buffer(from_idx, to_idx)
+local function swap_buffer(from_idx, to_idx)
   to_idx = max(1, min(#state.buffers, to_idx))
   if to_idx == from_idx then
     return
@@ -327,23 +327,30 @@ function api.move_current_buffer_to(idx)
     return notify_buffer_not_found(current_bufnr)
   end
 
-  move_buffer(from_idx, idx)
+  swap_buffer(from_idx, idx)
+end
+
+--- Move the current buffer a certain number of times over.
+--- @param buffer_number integer
+--- @param steps integer
+--- @return nil
+function api.move_buffer(buffer_number, steps)
+  render.update()
+
+  local idx = index_of(state.buffers, buffer_number)
+
+  if idx == nil then
+    return notify_buffer_not_found(buffer_number)
+  end
+
+  swap_buffer(idx, idx + steps)
 end
 
 --- Move the current buffer a certain number of times over.
 --- @param steps integer
 --- @return nil
 function api.move_current_buffer(steps)
-  render.update()
-
-  local current_bufnr = get_current_buf()
-  local idx = index_of(state.buffers, current_bufnr)
-
-  if idx == nil then
-    return notify_buffer_not_found(current_bufnr)
-  end
-
-  move_buffer(idx, idx + steps)
+  api.move_buffer(get_current_buf(), steps)
 end
 
 --- Order the buffers by their buffer number.

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -9,30 +9,113 @@ local buf_set_var = vim.api.nvim_buf_set_var --- @type function
 local command = vim.api.nvim_command --- @type function
 local create_augroup = vim.api.nvim_create_augroup --- @type function
 local create_autocmd = vim.api.nvim_create_autocmd --- @type function
+local create_namespace = vim.api.nvim_create_namespace
 local defer_fn = vim.defer_fn
 local del_autocmd = vim.api.nvim_del_autocmd --- @type function
 local exec_autocmds = vim.api.nvim_exec_autocmds --- @type function
 local get_option = vim.api.nvim_get_option --- @type function
+local on_key = vim.on_key
+local replace_termcodes = vim.api.nvim_replace_termcodes
 local schedule_wrap = vim.schedule_wrap
 local set_current_buf = vim.api.nvim_set_current_buf --- @type function
 local tbl_isempty = vim.tbl_isempty
 local win_get_position = vim.api.nvim_win_get_position --- @type function
 local win_get_width = vim.api.nvim_win_get_width --- @type function
 
+local api = require('barbar.api')
 local bdelete = require('barbar.bbye').bdelete
 local config = require('barbar.config')
 local highlight_reset_cache = require('barbar.utils.highlight').reset_cache
 local highlight_setup = require('barbar.highlight').setup
 local jump_mode = require('barbar.jump_mode')
+local layout = require('barbar.ui.layout')
 local render = require('barbar.ui.render')
-local set_offset = require('barbar.api').set_offset
 local state = require('barbar.state')
 
 --- The `<mods>` used for the close click handler
 local CLOSE_CLICK_MODS = vim.api.nvim_cmd and { confirm = true } or 'confirm'
 
+--- The starting index (of a buffer in `layout.buffers`) which was hovered while dragging
+--- @type nil|integer
+local drag_bufnr_start_idx = nil
+
 --- Whether barbar is currently set up to render.
 local enabled = false
+
+--- Handlers for `on_key` mouse dragging
+--- @type (fun(): nil)[]
+local handlers = {}
+
+--- Find which buffer fits within the `min_width`, from the `start_idx` onwards
+--- @param buffers barbar.ui.layout.data.buffers
+--- @param start_idx integer
+--- @param min_width integer
+--- @return integer|nil index
+local function get_idx(buffers, start_idx, min_width)
+  local base_widths = buffers.base_widths
+  local padding = buffers.padding
+
+  local idx = nil
+  local total_width = 0
+
+  for i = start_idx, #base_widths do
+    local base_width = base_widths[i]
+    local width = layout.calculate_width(base_width, padding)
+    total_width = total_width + width
+    if total_width >= min_width then
+      idx = i
+      break
+    end
+  end
+
+  return idx
+end
+
+--- What to do while dragging the mouse
+--- @return nil
+local function mouse_drag_handler()
+  if not (enabled and config.options.clickable) then
+    return
+  end
+
+  local ok, pos = pcall(vim.fn.getmousepos)
+  if (not ok) or pos.screenrow > 1 then
+    return
+  end
+
+  local col = pos.screencol
+  local data = layout.calculate()
+
+  local buffers_data = data.buffers
+  local start_col = data.left.width
+  if col < start_col or col > start_col + buffers_data.width then
+    return
+  end
+
+  local scroll = render.get_scroll()
+  local first_visible_bufnr_idx = get_idx(buffers_data, 1, scroll.current)
+  if first_visible_bufnr_idx == nil then
+    return
+  end
+
+  local hovered_bufnr_idx = get_idx(buffers_data, first_visible_bufnr_idx, col)
+
+  if drag_bufnr_start_idx == nil then
+    drag_bufnr_start_idx = hovered_bufnr_idx
+  elseif drag_bufnr_start_idx ~= hovered_bufnr_idx then
+    local first_hovered_bufnr = layout.buffers[drag_bufnr_start_idx]
+    local steps = hovered_bufnr_idx - drag_bufnr_start_idx
+    api.move_buffer(first_hovered_bufnr, steps)
+
+    drag_bufnr_start_idx = hovered_bufnr_idx
+  end
+end
+
+--- What to do when finishing a mouse drag
+--- @return nil
+local function mouse_drag_release_handler()
+  drag_bufnr_start_idx = nil
+end
 
 --- @class barbar.Events
 local events = {}
@@ -207,7 +290,7 @@ function events.enable()
               if width ~= widths[ft] then
                 widths[side][ft] = width
                 widths[other_side][ft] = nil
-                set_offset(total_widths(side), option.text, nil, side)
+                api.set_offset(total_widths(side), option.text, nil, side)
               end
             end,
             group = augroup_render,
@@ -222,7 +305,7 @@ function events.enable()
             buffer = tbl.buf,
             callback = function()
               widths[side][ft] = nil
-              set_offset(total_widths(side), nil, nil, side)
+              api.set_offset(total_widths(side), nil, nil, side)
               pcall(del_autocmd, autocmd)
             end,
             group = augroup_render,
@@ -336,6 +419,22 @@ function events.on_option_changed(user_config)
   config.setup(user_config) -- NOTE: must be first `setup` called here
   highlight_setup()
   jump_mode.set_letters(config.options.letters)
+
+  if config.options.clickable and vim.tbl_isempty(handlers) then
+    handlers[replace_termcodes('<LeftDrag>', true, true, true)] = mouse_drag_handler
+    handlers[replace_termcodes('<LeftRelease>', true, true, true)] = mouse_drag_release_handler
+    handlers[replace_termcodes('<MiddleDrag>', true, true, true)] = mouse_drag_handler
+    handlers[replace_termcodes('<MiddleRelease>', true, true, true)] = mouse_drag_handler
+    handlers[replace_termcodes('<RightDrag>', true, true, true)] = mouse_drag_handler
+    handlers[replace_termcodes('<RightRelease>', true, true, true)] = mouse_drag_release_handler
+
+    on_key(function(key)
+      local handler = handlers[key]
+      if handler then
+        handler()
+      end
+    end, create_namespace('barbar'))
+  end
 
   -- Don't jump-start barbar if it is disabled
   if enabled then

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -42,6 +42,7 @@ local WARN = severity.WARN
 --- @field computed_width? integer the width of the buffer plus invisible characters
 --- @field diagnostics? {[DiagnosticSeverity]: integer}
 --- @field gitsigns? {[barbar.config.options.icons.buffer.git.statuses]: integer} the real position of the buffer
+--- @field moving? boolean whether the buffer is currently being repositioned
 --- @field name? string the name of the buffer
 --- @field pinned boolean whether the buffer is pinned
 --- @field position? integer the absolute position of the buffer

--- a/lua/barbar/ui/render.lua
+++ b/lua/barbar/ui/render.lua
@@ -231,6 +231,11 @@ local function open_buffers(new_buffers)
   end
 end
 
+--- @return barbar.ui.render.scroll scroll
+function render.get_scroll()
+  return scroll
+end
+
 --- Refresh the buffer list.
 --- @return integer[] state.buffers
 function render.get_updated_buffers(update_names)


### PR DESCRIPTION
Closes #261 

The feature is automatically enabled when `clickable = true` during `setup`.

Todo:

* [ ] gif on readme?
* [x] ~~check `on_key` isn't _required_~~ (it was)