### PR TITLE
fix: reference to nvim 0.8 highlight attributes when on nvim 0.7

### DIFF
--- a/lua/barbar/highlight.lua
+++ b/lua/barbar/highlight.lua
@@ -99,8 +99,7 @@ local highlight = {}
 function highlight.setup()
   local preset = config.options.icons.preset
 
-  local fg_target = {gui = 'red'} --- @type barbar.utils.hl.color
-  fg_target.cterm = fg_target.gui
+  local fg_target = {gui = 'red', cterm = 'red'} --- @type barbar.utils.hl.color
 
   local fg_added = hl.fg_or_default({'GitSignsAdd'}, '#59ff5a', 82)
   local fg_changed = hl.fg_or_default({'GitSignsChange'}, '#599eff', 75)
@@ -139,19 +138,14 @@ function highlight.setup()
   if config.options.highlight_alternate then
     local alternate_hl = {'TabLine', 'StatusLine'}
 
-    local attributes = hl.attributes(alternate_hl) or {}
+    local attributes = hl.definition(alternate_hl) or {}
 
     local bg = hl.bg_or_default(alternate_hl, 'none')
     local fg = hl.fg_or_default(alternate_hl, 0xEAD0A0, 223)
     local sp --- @type barbar.utils.hl.color.value
 
     if preset == 'default' then
-      attributes.undercurl = false
-      attributes.underdashed = false
-      attributes.underdotted = false
-      attributes.underdouble = false
-      attributes.underline = false
-
+      hl.remove_underline_attributes(attributes)
       hl.set('BufferDefaultAlternateSign', bg, fg_special, sp, attributes)
     else
       sp = hl.fg_or_default({'DiagnosticSignHint'}, 0xD5508F).gui
@@ -181,18 +175,13 @@ function highlight.setup()
   do
     local current_hl = {'TabLineSel'}
 
-    local attributes = hl.attributes(current_hl) or {}
+    local attributes = hl.definition(current_hl) or {}
     local bg = hl.bg_or_default(current_hl, 'none')
     local fg = hl.fg_or_default(current_hl, '#efefef', 255)
     local sp --- @type barbar.utils.hl.color.value
 
     if preset == 'default' then
-      attributes.undercurl = false
-      attributes.underdashed = false
-      attributes.underdotted = false
-      attributes.underdouble = false
-      attributes.underline = false
-
+      hl.remove_underline_attributes(attributes)
       hl.set('BufferDefaultCurrentSign', bg, fg_special, sp, attributes)
     else
       sp = hl.sp_or_default(current_hl, 0x60AFFF)
@@ -222,12 +211,8 @@ function highlight.setup()
   do
     local inactive_hl = {'TabLine', 'StatusLine'}
 
-    local attributes = hl.attributes(inactive_hl) or {}
-    attributes.undercurl = false
-    attributes.underdashed = false
-    attributes.underdotted = false
-    attributes.underdouble = false
-    attributes.underline = false
+    local attributes = hl.definition(inactive_hl) or {}
+    hl.remove_underline_attributes(attributes)
 
     local bg = hl.bg_or_default(inactive_hl, 'none')
     local fg = hl.fg_or_default(inactive_hl, '#efefef', 255)
@@ -259,18 +244,13 @@ function highlight.setup()
   if config.options.highlight_visible then
     local visible_hl = {'TabLine', 'StatusLine'}
 
-    local attributes = hl.attributes(visible_hl) or {}
+    local attributes = hl.definition(visible_hl) or {}
     local bg = hl.bg_or_default(visible_hl, 'none')
     local fg = hl.fg_or_default(visible_hl, '#efefef', 255)
     local sp --- @type barbar.utils.hl.color.value
 
     if preset == 'default' then
-      attributes.undercurl = false
-      attributes.underdashed = false
-      attributes.underdotted = false
-      attributes.underdouble = false
-      attributes.underline = false
-
+      hl.remove_underline_attributes(attributes)
       hl.set('BufferDefaultVisibleSign', bg, fg, sp, attributes)
     else
       sp = hl.fg_or_default({'Delimiter'}, 0xFFFFFF).gui

--- a/lua/barbar/icons.lua
+++ b/lua/barbar/icons.lua
@@ -26,7 +26,7 @@ local function hl_buffer_icon(buffer_status, icon_hl)
     hl.bg_or_default(buffer_status_hl, 'none'),
     hl.fg_or_default({icon_hl}, 'none'),
     hl.sp_or_default(buffer_status_hl, 'none'),
-    hl.attributes(buffer_status_hl)
+    hl.definition(buffer_status_hl)
   )
 end
 

--- a/lua/barbar/utils/highlight.lua
+++ b/lua/barbar/utils/highlight.lua
@@ -85,21 +85,17 @@ end
 --- @field cterm barbar.utils.hl.color.value
 --- @field gui barbar.utils.hl.color.value
 
+--- @class barbar.utils.hl.definition: barbar.utils.hl.attributes
+--- @field bg? barbar.utils.hl.color.value
+--- @field cterm? barbar.utils.hl.attributes
+--- @field ctermbg? barbar.utils.hl.color.value
+--- @field ctermfg? barbar.utils.hl.color.value
+--- @field fg? barbar.utils.hl.color.value
+--- @field sp? barbar.utils.hl.color.value
+
 --- utilities for working with highlight groups.
 --- @class barbar.utils.Hl
 local hl = {}
-
---- Generate a color.
---- @param groups string[] the groups to source the color from.
---- @return nil|barbar.utils.hl.attributes
-function hl.attributes(groups)
-  for _, group in ipairs(groups) do
-    local cached = get_hl_cached(group)
-    if not tbl_isempty(cached) then
-      return vim.deepcopy(cached)
-    end
-  end
-end
 
 --- Generate a background color.
 --- @param groups string[] the groups to source the background color from.
@@ -111,6 +107,18 @@ function hl.bg_or_default(groups, default, default_cterm)
     cterm = get_hl_color_or_default(groups, 'ctermbg', default_cterm or default),
     gui = get_hl_color_or_default(groups, 'bg', default),
   }
+end
+
+--- Generate a color.
+--- @param groups string[] the groups to source the color from.
+--- @return nil|barbar.utils.hl.definition
+function hl.definition(groups)
+  for _, group in ipairs(groups) do
+    local cached = get_hl_cached(group)
+    if not tbl_isempty(cached) then
+      return vim.deepcopy(cached)
+    end
+  end
 end
 
 --- Generate a foreground color.
@@ -129,27 +137,27 @@ end
 function hl.reset_cache() hl_groups_cache = {} end
 
 --- Set some highlight `group`'s default definition with respect to `&termguicolors`
---- WARN: this mutates `attributes`!
+--- WARN: this mutates `definition`!
 --- @param group string the name of the highlight group to set
 --- @param bg barbar.utils.hl.color
 --- @param fg barbar.utils.hl.color
 --- @param sp? barbar.utils.hl.color.value
---- @param attributes? barbar.utils.hl.attributes whether the highlight group should be bolded
+--- @param definition? barbar.utils.hl.definition whether the highlight group should be bolded
 --- @return nil
-function hl.set(group, bg, fg, sp, attributes)
-  if not attributes then
-    attributes = {}
+function hl.set(group, bg, fg, sp, definition)
+  if not definition then
+    definition = {}
   end
 
-  attributes.bg = bg.gui
-  attributes.ctermbg = bg.cterm
-  attributes.ctermfg = fg.cterm
-  attributes.fg = fg.gui
-  attributes.reverse = nil
-  attributes.sp = sp
-  attributes[vim.type_idx] = nil
+  definition.bg = bg.gui
+  definition.ctermbg = bg.cterm
+  definition.ctermfg = fg.cterm
+  definition.fg = fg.gui
+  definition.reverse = nil
+  definition.sp = sp
+  definition[vim.type_idx] = nil
 
-  set_hl(0, group, attributes)
+  set_hl(0, group, definition)
 end
 
 --- Set the default highlight `group_name` as a link to `link_name`

--- a/lua/barbar/utils/highlight.lua
+++ b/lua/barbar/utils/highlight.lua
@@ -136,6 +136,26 @@ end
 --- Reset the `nvim_get_hl` cache
 function hl.reset_cache() hl_groups_cache = {} end
 
+--- Remove all attributes related to underlining from the definition provided
+--- WARN: mutates `definition`!
+--- @param definition barbar.utils.hl.definition the definition to remove underline from
+--- @return nil
+function hl.remove_underline_attributes(definition)
+  definition.undercurl = nil
+  definition.underdashed = nil
+  definition.underdotted = nil
+  definition.underdouble = nil
+  definition.underline = nil
+
+  if definition.cterm then
+    definition.cterm.undercurl = nil
+    definition.cterm.underdashed = nil
+    definition.cterm.underdotted = nil
+    definition.cterm.underdouble = nil
+    definition.cterm.underline = nil
+  end
+end
+
 --- Set some highlight `group`'s default definition with respect to `&termguicolors`
 --- WARN: this mutates `definition`!
 --- @param group string the name of the highlight group to set


### PR DESCRIPTION
Closes #547 

`underdouble` etc. are only available 0.8+
