### PR TITLE
fix: mouse drag offset bug when nvim-tree enabled

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -56,7 +56,7 @@ local function get_idx(buffers, start_idx, min_width)
   local padding = buffers.padding
 
   local idx = nil
-  local total_width = 0
+  local total_width = state.offset.left.width
 
   for i = start_idx, #base_widths do
     local base_width = base_widths[i]


### PR DESCRIPTION
When the nvim-tree plugin is open, the initial offset during mouse dragging should not be a fixed value of 0.
This is rough method of modification, please refer to it, thank you very much!