### PR TITLE
feat: scope.nvim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,13 +452,37 @@ in the demos above.
 
 ## Integrations
 
+#### [scope.nvim]
+
+To preserve buffer order while using [scope.nvim], you can add this to your config:
+
+```lua
+require('scope').setup {
+  hooks = {
+    pre_tab_leave = function()
+      vim.api.nvim_exec_autocmds('User', {pattern = 'ScopeTabLeavePre'})
+      -- [other statements]
+    end,
+
+    post_tab_enter = function()
+      vim.api.nvim_exec_autocmds('User', {pattern = 'ScopeTabEnterPost'})
+      -- [other statements]
+    end,
+
+    -- [other hooks]
+  },
+
+  -- [other options]
+}
+```
+
 #### Sessions
 
 `barbar.nvim` can restore the order that your buffers were in, as well as whether a buffer was pinned. To do this, `sessionoptions` must contain `globals`, and the `User SessionSavePre` event must be executed before `:mksession`.
 
-##### mini.nvim
+##### [mini.nvim]
 
-Here is a `mini.sessions` config which can be used:
+Here is a [mini.sessions][mini.nvim] config which can be used:
 
 ```lua
 vim.opt.sessionoptions:append 'globals'
@@ -471,9 +495,9 @@ require'mini.sessions'.setup {
 }
 ```
 
-##### persistence.nvim
+##### [persistence.nvim]
 
-Here is a `persistence.nvim` config which can be used:
+Here is a [persistence.nvim] config which can be used:
 
 ```lua
 require'persistence'.setup {
@@ -536,3 +560,7 @@ No, barbar has nothing to do with barbarians.
 
 * **barbar.nvim:** Distributed under the terms of the JSON license.
 * **bbye.vim:** Distributed under the terms of the GNU Affero license.
+
+[mini.nvim]: https://github.com/echasnovski/mini.nvim
+[persistence.nvim]: https://github.com/folke/persistence.nvim
+[scope.nvim]: https://github.com/tiagovla/scope.nvim

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -543,29 +543,53 @@ tabpages ~
 5. Integrations                                          *barbar-integrations*
 
 ------------------------------------------------------------------------------
-SESSIONS                                        *barbar-integrations-sessions*
+SCOPE.NVIM                                      *barbar-integrations-scope.nvim*
+
+Add this to your |scope.nvim-configuration| to preserve buffer order while
+switching tabs: >lua
+  require('scope').setup {
+    hooks = {
+      pre_tab_leave = function()
+        vim.api.nvim_exec_autocmds('User', {pattern = 'ScopeTabLeavePre'})
+        -- [other statements]
+      end,
+
+      post_tab_enter = function()
+        vim.api.nvim_exec_autocmds('User', {pattern = 'ScopeTabEnterPost'})
+        -- [other statements]
+      end,
+
+      -- [other hooks]
+    },
+
+    -- [other options]
+  }
+<
+
+------------------------------------------------------------------------------
+SESSIONS                                          *barbar-integrations-sessions*
 
 |barbar.nvim| can restore the order that your buffers were in, as well as
 whether a buffer was pinned. To do this, 'sessionoptions' must contain
 `globals`, and the |User| `SessionSavePre` event must be executed before
 |:mksession| executes.
 
-                                      *barbar-integrations-sessions-mini.nvim*
-mini.nvim ~
+MINI.NVIM                               *barbar-integrations-sessions-mini.nvim*
 
 Here is a |mini.sessions| config which can be used: >
   vim.opt.sessionoptions:append 'globals'
   require'mini.sessions'.setup {
     hooks = {
       pre = {
-        write = function() vim.api.nvim_exec_autocmds('User', {pattern = 'SessionSavePre'}) end,
+        write = function()
+          vim.api.nvim_exec_autocmds('User', {pattern = 'SessionSavePre'})
+        end,
       },
     },
   }
 <
 
-                               *barbar-integrations-sessions-persistence.nvim*
-persistence.nvim ~
+PERSISTENCE.NVIM                 *barbar-integrations-sessions-persistence.nvim*
 
 Here is a |persistence.nvim| config which can be used: >
   require'persistence'.setup {
@@ -576,8 +600,7 @@ Here is a |persistence.nvim| config which can be used: >
   }
 <
 
-                                         *barbar-integrations-sessions-custom*
-Custom ~
+CUSTOM                                     *barbar-integrations-sessions-custom*
 
 You can add this snippet to your config to take advantage of our session
 integration: >

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -351,18 +351,7 @@ function events.enable()
 
   create_autocmd('User', {
     callback = function()
-      local relative = require('barbar.fs').relative
-
-      --- List of open buffers, along with relevant data
-      local buffers = {}
-
-      for _, bufnr in ipairs(state.buffers) do
-        table_insert(buffers, {
-          name = relative(buf_get_name(bufnr)),
-          pinned = state.is_pinned(bufnr) or nil,
-        })
-      end
-
+      local buffers = state.export_buffers()
       vim.g.Bufferline__session_restore = "lua require('barbar.state').restore_buffers " ..
         vim.inspect(buffers, {newline = ' ', indent = ''})
     end,

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -14,6 +14,7 @@ local create_namespace = vim.api.nvim_create_namespace
 local defer_fn = vim.defer_fn
 local del_autocmd = vim.api.nvim_del_autocmd --- @type function
 local exec_autocmds = vim.api.nvim_exec_autocmds --- @type function
+local get_current_tabpage = vim.api.nvim_get_current_tabpage
 local get_option = vim.api.nvim_get_option --- @type function
 local on_key = vim.on_key
 local replace_termcodes = vim.api.nvim_replace_termcodes
@@ -348,6 +349,30 @@ function events.enable()
     callback = function() render.update(true) end,
     group = augroup_render,
   })
+
+  do
+    local buffers_by_tab = {}
+    create_autocmd('User', {
+      callback = function()
+        local tab = get_current_tabpage()
+        buffers_by_tab[tab] = state.export_buffers()
+      end,
+      group = augroup_misc,
+      pattern = 'ScopeTabLeavePre',
+    })
+
+    create_autocmd('User', {
+      callback = function()
+        local tab = get_current_tabpage()
+        local buffers = buffers_by_tab[tab]
+        if buffers then
+          state.restore_buffers(buffers)
+        end
+      end,
+      group = augroup_misc,
+      pattern = 'ScopeTabEnterPost',
+    })
+  end
 
   create_autocmd('User', {
     callback = function()

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -36,7 +36,7 @@ local WARN = severity.WARN
 -- Section: Application state --
 --------------------------------
 
---- @class barbar.state.data
+--- @class barbar.state.buffer.data
 --- @field closing boolean whether the buffer is being closed
 --- @field computed_position? integer the real position of the buffer
 --- @field computed_width? integer the width of the buffer plus invisible characters
@@ -60,7 +60,7 @@ local WARN = severity.WARN
 
 --- @class barbar.State
 --- @field buffers integer[] the open buffers, in visual order.
---- @field data_by_bufnr {[integer]: barbar.state.data} the buffer data indexed on buffer number
+--- @field data_by_bufnr {[integer]: barbar.state.buffer.data} the buffer data indexed on buffer number
 --- @field is_picking_buffer boolean whether the user is currently in jump-mode
 --- @field last_current_buffer? integer the previously-open buffer before rendering starts
 --- @field offset barbar.state.offset
@@ -78,7 +78,7 @@ local state = {
 
 --- Get the state of the `id`
 --- @param bufnr integer the `bufnr`
---- @return barbar.state.data
+--- @return barbar.state.buffer.data
 function state.get_buffer_data(bufnr)
   if bufnr == 0 then
     bufnr = get_current_buf()
@@ -314,6 +314,26 @@ function state.set_offset(width, text, hl)
   )
 
   require('barbar.api').set_offset(width, text, hl)
+end
+
+--- @class barbar.state.buffer.exported
+--- @field name string the name of the buffer
+--- @field pinned boolean whether the buffer is pinned
+
+--- Exports buffers to a format which is acceptable by `restore_buffers`
+--- @return barbar.state.buffer.exported[]
+--- @see barbar.State.restore_buffers
+function state.export_buffers()
+    local buffers = {} --- @type barbar.state.buffer.exported[]
+
+    for _, bufnr in ipairs(state.buffers) do
+      table_insert(buffers, {
+        name = fs.relative(buf_get_name(bufnr)),
+        pinned = state.is_pinned(bufnr) or nil,
+      })
+    end
+
+    return buffers
 end
 
 --- Restore the buffers


### PR DESCRIPTION
Closes #556 

```lua
require('scope').setup {
  hooks = {
    pre_tab_leave = function()
      vim.api.nvim_exec_autocmds('User', {pattern = 'ScopeTabLeavePre'})
      -- [other statements]
    end,

    post_tab_enter = function()
      vim.api.nvim_exec_autocmds('User', {pattern = 'ScopeTabEnterPost'})
      -- [other statements]
    end,

    -- [other hooks]
  },

  -- [other options]
}
```