### PR TITLE
feat: luarocks support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,32 @@
+---
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            nvim-web-devicons
+            gitsigns.nvim


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

See also:

- [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
- [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).

### Things done:

- Add a workflow that publishes tags to luarocks.org when a tag or release is pushed.

### Notes:

- This PR is blocked by https://github.com/lewis6991/gitsigns.nvim/pull/964
- Tagged releases are installed locally and then published to luarocks.org.
- For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
- Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.

See also [this guide](https://github.com/vhyrro/sample-luarocks-plugin).