### PR TITLE
docs: add persisted.nvim to sessions integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,21 @@ require'persistence'.setup {
 }
 ```
 
+##### [persisted.nvim]
+
+Here is a [persisted.nvim] config which can be used:
+
+```lua
+vim.opt.sessionoptions:append 'globals'
+vim.api.nvim_create_autocmd({ 'User' }, {
+  pattern = 'PersistedSavePre',
+  group = vim.api.nvim_create_augroup('PersistedHooks', {}),
+  callback = function()
+    vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
+  end,
+})
+```
+
 ##### Custom
 
 You can add this snippet to your config to take advantage of our session integration:
@@ -565,4 +580,5 @@ No, barbar has nothing to do with barbarians.
 
 [mini.nvim]: https://github.com/echasnovski/mini.nvim
 [persistence.nvim]: https://github.com/folke/persistence.nvim
+[persisted.nvim]: https://github.com/olimorris/persisted.nvim
 [scope.nvim]: https://github.com/tiagovla/scope.nvim

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -599,6 +599,19 @@ Here is a |persistence.nvim| config which can be used: >lua
       vim.api.nvim_exec_autocmds('User', {pattern = 'SessionSavePre'})
     end,
   }
+
+
+PERSISTED.NVIM                     *barbar-integrations-sessions-persisted.nvim*
+
+Here is a |persisted.nvim| config which can be used: >lua
+  vim.opt.sessionoptions:append 'globals'
+  vim.api.nvim_create_autocmd({ 'User' }, {
+    pattern = 'PersistedSavePre',
+    group = vim.api.nvim_create_augroup('PersistedHooks', {}),
+    callback = function()
+      vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
+    end,
+  })
 <
 
 CUSTOM                                     *barbar-integrations-sessions-custom*


### PR DESCRIPTION
I'm using [persisted.nvim](https://github.com/olimorris/persisted.nvim) as a session manager and I followed its [docs](https://github.com/olimorris/persisted.nvim?tab=readme-ov-file#events--callbacks) to integrate buffer saving with barbar, which can be added to the docs in case anyone wants to do the same.