### PR TITLE
fix(bbye): fix switch window failure

### DIFF
--- a/lua/barbar/bbye.lua
+++ b/lua/barbar/bbye.lua
@@ -156,7 +156,7 @@ function bbye.delete(action, force, buffer, mods)
   local wins = list_wins()
   for i = #wins, 1, -1 do
     local window_number = wins[i]
-    if win_get_buf(window_number) == buffer_number then
+    if win_is_valid(window_number) and win_get_buf(window_number) == buffer_number then
       set_current_win(window_number)
 
       -- Bprevious also wraps around the buffer list, if necessary:


### PR DESCRIPTION
Sometimes I met such error when use `BufferClose` to delete current buffer:

![image](https://github.com/romgrk/barbar.nvim/assets/6496887/9ab432f4-ea50-47ad-a170-8a05311e5297)

I add a `win_is_valid` check before calling `set_current_win` API.