### PR TITLE
fix(bbye): fix switch window failure again with 'pcall'

### DIFF
--- a/lua/barbar/bbye.lua
+++ b/lua/barbar/bbye.lua
@@ -191,6 +191,12 @@ function bbye.delete(action, force, buffer, mods)
   -- Using buflisted() over bufexists() because bufhidden=delete causes the
   -- buffer to still _exist_ even though it won't be :bdelete-able.
   if buflisted(buffer_number) == 1 and buffer_number ~= get_current_buf() then
+    -- Disable auto commands when executing bdelete/bwipeout on a buffer
+    if type(mods) == 'string' then
+      mods = mods .. ' noautocmd'
+    elseif type(mods) == 'table' then
+      mods.noautocmd = true
+    end
     local ok, msg = pcall(cmd, action, buffer_number, force, mods)
     if not ok then
       if msg then

--- a/lua/barbar/bbye.lua
+++ b/lua/barbar/bbye.lua
@@ -157,7 +157,7 @@ function bbye.delete(action, force, buffer, mods)
   for i = #wins, 1, -1 do
     local window_number = wins[i]
     if win_is_valid(window_number) and win_get_buf(window_number) == buffer_number then
-      set_current_win(window_number)
+      pcall(set_current_win,window_number)
 
       -- Bprevious also wraps around the buffer list, if necessary:
       local ok = pcall(function()


### PR DESCRIPTION
Fix #583 .

Previous PR: #579 .

This PR try to avoid throwing exception when fail to set current window to the `window_number` variable.

When testing this PR with my personal nvim config, it can really delete the `lazy-lock.json` buffer, but there shows up another error:

<img width="1920" alt="image" src="https://github.com/romgrk/barbar.nvim/assets/6496887/71173d17-e6ca-4e72-9beb-97e50810c96d">

I guess the root cause is, when delete or edit a new buffer, the command triggers the `DiagnosticChanged` autocommands.

Note: I use this key mapping to test the `BufferClose`:
`vim.keymap.set("n", "<leader>bd", "<cmd>BufferClose<CR>", {silent=true, noremap=true, desc = "Delete buffer"}

So I update the key mapping to: `"<cmd>noautocmd BufferClose<CR>"`, but the `bbye` module's behavior still seems not correct!