### PR TITLE
fix: add check to ensure that buffer is loaded

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -222,8 +222,10 @@ function events.enable()
 
   create_autocmd('DiagnosticChanged', {
     callback = function(event)
-      state.update_diagnostics(event.buf)
-      render.update()
+      if vim.api.nvim_buf_is_loaded(event.buf) then
+        state.update_diagnostics(event.buf)
+        render.update()
+      end
     end,
     group = augroup_render,
   })


### PR DESCRIPTION
This should resolve #583. The `DiagnosticChanged` event was firing when closing buffers, causing Barbar to try to render a nonexistent buffer. I just added an if statement to account for this; it seems to work in my testing now.