### PR TITLE
feat: case-insentive sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,12 @@ require'barbar'.setup {
   -- Sets the name of unnamed buffers. By default format is "[Buffer X]"
   -- where X is the buffer number. But only a static string is accepted here.
   no_name_title = nil,
+
+  -- sorting options
+  sort = {
+    -- tells barbar to ignore case differences while sorting buffers
+    ignore_case = true,
+  },
 }
 ```
 

--- a/doc/barbar.txt
+++ b/doc/barbar.txt
@@ -535,6 +535,16 @@ sidebar_filetypes ~
     }}
 <
 
+                                                             *barbar-setup.sort*
+sort ~
+  Configures the `:BufferOrderBy*` commands.
+
+                                                 *barbar-setup.sort.ignore_case*
+  sort.ignore_case ~
+    `boolean` (default `false`)
+    If `true`, comparisons of names in buffer orderings will not take into
+    account differences in case (e.g. 'a' will equal 'A').
+
                                                          *barbar-setup.tabpages*
 tabpages ~
   `boolean`  (default: `true`)

--- a/lua/barbar/api.lua
+++ b/lua/barbar/api.lua
@@ -371,12 +371,12 @@ end
 --- Order the buffers by their name
 --- @return nil
 function api.order_by_name()
-  table_sort(state.buffers, with_pin_order(function(a, b)
+  table_sort(state.buffers, with_pin_order(function(a, b, to_sort_case)
     local parts_of_a = vim.split(buf_get_name(a), '/')
     local parts_of_b = vim.split(buf_get_name(b), '/')
     local name_of_a = parts_of_a[#parts_of_a]
     local name_of_b = parts_of_b[#parts_of_b]
-    return name_of_b > name_of_a
+    return to_sort_case(name_of_b) > to_sort_case(name_of_a)
   end))
 
   render.update()
@@ -385,10 +385,10 @@ end
 --- Order the buffers by their parent directory.
 --- @return nil
 function api.order_by_directory()
-  table_sort(state.buffers, with_pin_order(function(a, b)
+  table_sort(state.buffers, with_pin_order(function(a, b, to_sort_case)
     local name_of_a = buf_get_name(a)
     local name_of_b = buf_get_name(b)
-    local compare_a_b = name_of_b > name_of_a
+    local compare_a_b = to_sort_case(name_of_b) > to_sort_case(name_of_a)
 
     -- TODO: remove this block after 0.8 releases
     if not normalize then
@@ -416,8 +416,8 @@ end
 --- Order the buffers by filetype.
 --- @return nil
 function api.order_by_language()
-  table_sort(state.buffers, with_pin_order(function(a, b)
-    return buf_get_option(a, 'filetype') < buf_get_option(b, 'filetype')
+  table_sort(state.buffers, with_pin_order(function(a, b, to_sort_case)
+    return to_sort_case(buf_get_option(a, 'filetype')) < to_sort_case(buf_get_option(b, 'filetype'))
   end))
 
   render.update()

--- a/lua/barbar/api.lua
+++ b/lua/barbar/api.lua
@@ -63,9 +63,7 @@ end
 --- @param order_func fun(bufnr_a: integer, bufnr_b: integer, to_sort_case: fun(s: string): string): boolean accepts `(integer, integer)` params.
 --- @return fun(bufnr_a: integer, bufnr_b: integer): boolean
 local function with_pin_order(order_func)
-  local to_sort_case = config.options.sort.ignore_case and function(s)
-    return tolower(s)
-  end or function(s)
+  local to_sort_case = config.options.sort.ignore_case and tolower or function(s)
     return s
   end
 

--- a/lua/barbar/config.lua
+++ b/lua/barbar/config.lua
@@ -194,6 +194,9 @@ local DEPRECATED_OPTIONS = {
 --- @field event? string
 --- @field text? string
 
+--- @class barbar.config.options.sort
+--- @field ignore_case boolean
+
 --- @class barbar.config.options
 --- @field animation boolean
 --- @field auto_hide integer
@@ -216,6 +219,7 @@ local DEPRECATED_OPTIONS = {
 --- @field no_name_title? string
 --- @field semantic_letters boolean
 --- @field sidebar_filetypes {[string]: nil|barbar.config.options.sidebar_filetype}
+--- @field sort barbar.config.options.sort
 --- @field tabpages boolean
 
 --- @class barbar.Config
@@ -341,6 +345,7 @@ function config.setup(options)
     preset = 'default',
     semantic_letters = true,
     sidebar_filetypes = {},
+    sort = { ignore_case = false },
     tabpages = true,
   })
 


### PR DESCRIPTION
Closes #596.

This PR implements an option to enable case-insensitive sorting in barbar.nvim:

```lua
require'barbar'.setup {
  sort = { ignore_case = true },
}
```

Documentation was added, and the existing sorting functions were updates to respect the user's configuration.