### PR TITLE
fix(events): respond to gitsigns update in remote buffers

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -232,7 +232,14 @@ function events.enable()
 
   create_autocmd('User', {
     callback = vim.schedule_wrap(function(event)
-      state.update_gitsigns(event.buf)
+      local bufnr
+      if event.data == nil or event.data.buffer == nil then
+        bufnr = event.buf
+      else
+        bufnr = event.data.buffer
+      end
+
+      state.update_gitsigns(bufnr)
       render.update()
     end),
     group = augroup_render,


### PR DESCRIPTION
It turns out that our gitsigns update autocmd was occasionally looking in the wrong place for the number of the buffer that had its signs updated.

It seems that it gitsigns may issue a secondary buffer number in the user data event field when the buffer whose signs were updated is different than the current buffer. I am not positive on the reason for this, but I will assume that it was well-informed.

Closes #604 