### PR TITLE
Normalize filepaths

### DIFF
--- a/lua/barbar/fs.lua
+++ b/lua/barbar/fs.lua
@@ -30,6 +30,11 @@ end
 --- implementation of certain functions can be simplified based on Neovim version
 if vim.fs then
   local normalize = vim.fs.normalize
+  local join = vim.fs.joinpath
+
+  --- Join file path parts into one normalized filepath
+  --- @type fun(...: string): string
+  fs.join = join
 
   --- create a standard format for the path.
   ---
@@ -45,8 +50,19 @@ if vim.fs then
     return normalize(path, { expand_env = false })
   end
 else
+  local table_concat = table.concat
+
   --- the OS' path separator (e.g. `/` on unix, `\` on windows)
   local os_path_separator = package.config:sub(1, 1)
+
+  --- @param ... string the parts to join into a path
+  --- @return string path the joined, normalized path
+  function fs.join(...)
+    local joined = table_concat({...}, '/')
+    local normalized = fs.normalize(joined)
+    return normalized
+  end
+
 
   --- a custom implementation of path normalization.
   ---

--- a/lua/barbar/fs.lua
+++ b/lua/barbar/fs.lua
@@ -100,6 +100,18 @@ function fs.relative(path)
   return fnamemodify(path, ':~:.')
 end
 
+--- # Example
+---
+--- ```lua
+--- fs.split '~/foo/bar/baz.lua' --> {'~', 'foo', 'bar', 'baz.lua'}
+--- ```
+---
+--- @param path string a (normalized) filepath to split
+--- @return string[] parts the sections of the filepath between separators
+function fs.split(path)
+  return vim.split(path, '/', { plain = true, trimempty = true })
+end
+
 --- @param filepath string
 --- @param content string
 --- @param mode? openmode

--- a/lua/barbar/fs.lua
+++ b/lua/barbar/fs.lua
@@ -7,6 +7,12 @@ local fnamemodify = vim.fn.fnamemodify --- @type function
 --- @class barbar.Fs
 local fs = {}
 
+--- @param path string
+--- @return string absolute_path
+function fs.absolute(path)
+  return fnamemodify(path, ':p')
+end
+
 --- Get
 --- @param path string
 --- @param hide_extension? boolean if `true`, exclude the extension of the file in the basename

--- a/lua/barbar/fs.lua
+++ b/lua/barbar/fs.lua
@@ -4,6 +4,8 @@
 
 local fnamemodify = vim.fn.fnamemodify --- @type function
 
+local list = require('barbar.utils.list') --- @type barbar.utils.List
+
 --- @class barbar.Fs
 local fs = {}
 
@@ -126,6 +128,23 @@ end
 --- @return string[] parts the sections of the filepath between separators
 function fs.split(path)
   return vim.split(path, '/', { plain = true, trimempty = true })
+end
+
+--- # Example
+---
+--- ```lua
+--- fs.slice_parts_from_end('~/foo/bar/baz', 2) --> 'bar/baz'
+--- ```
+---
+--- @param path string a (normalized) filepath from which to select a given number of ending parts
+--- @param desired_parts integer the number of parts which the final path should have
+--- @return string sliced_path the filepath with only the given number of desired parts left at the end
+function fs.slice_parts_from_end(path, desired_parts)
+  local parts = fs.split(path)
+  parts = list.slice_from_end(parts, desired_parts)
+
+  local desired_path = fs.join(unpack(parts))
+  return desired_path
 end
 
 --- @param filepath string


### PR DESCRIPTION
# Summary

After some discussion in #612, it was determined that we should expand upon the proposed set of changes in order to standardize how we handle filepaths throughout the plugin.

- The implementation leans into Neovim 0.8 features where available
- On Neovim 0.7, we provide basic implementations of those features to maintain compatibility

I'd like to give credit to @exzolink for figuring out how to solve #611 and presenting a solution which we could easily encapsulate!

## Checklist

- filepath utilities
  - [x] `Fs.absolute()`
  - [x] `Fs.normalize()`
  - [x] `Fs.join()`
  - [x] `Fs.split()`
  - [x] `Fs.slice_parts_from_end()`
- update handling of filepaths
  - [x] `Api.order_by_directory()`
  - [x] `Api.order_by_name()`
  - [x] `Buffer.get_name()`
  - [x] `Buffer.get_unique_names()`

## Items for Discussion

- [ ] Are there any remaining places where the new FS utilities should be used?
- [ ] Are the Nvim-0.7-backport implementations of the FS utilities satisfactory?

## Related

- Closes #611
- Closes #612
