### PR TITLE
Add resession extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,18 @@ vim.api.nvim_create_autocmd({ 'User' }, {
 })
 ```
 
+##### [resession.nvim]
+
+This plugin comes with support for [resession.nvim] through an extension. To enable, add the following snippet to your resession config:
+
+```lua
+extensions = {
+  barbar = {},
+}
+```
+
+If using [lazy.nvim](https://github.com/folke/lazy.nvim) then ensure you add barbar.nvim as a dependency to resession, to ensure that the extension loads before resession.
+
 ##### Custom
 
 You can add this snippet to your config to take advantage of our session integration:
@@ -594,4 +606,5 @@ No, barbar has nothing to do with barbarians.
 [mini.nvim]: https://github.com/echasnovski/mini.nvim
 [persistence.nvim]: https://github.com/folke/persistence.nvim
 [persisted.nvim]: https://github.com/olimorris/persisted.nvim
+[resession.nvim]: https://github.com/stevearc/resession.nvim
 [scope.nvim]: https://github.com/tiagovla/scope.nvim

--- a/lua/resession/extensions/barbar.lua
+++ b/lua/resession/extensions/barbar.lua
@@ -1,0 +1,18 @@
+local M = {}
+local render = require("barbar.ui.render")
+local state = require("barbar.state")
+
+M.on_save = function()
+  local buffers = state.export_buffers()
+  return "lua require('barbar.state').restore_buffers "
+    .. vim.inspect(buffers, { newline = " ", indent = "" })
+end
+
+M.on_post_load = function(data)
+  if data then
+    vim.api.nvim_command(data)
+  end
+  render.update(true)
+end
+
+return M

--- a/lua/resession/extensions/barbar.lua
+++ b/lua/resession/extensions/barbar.lua
@@ -1,15 +1,15 @@
 local M = {}
-local render = require("barbar.ui.render")
-local state = require("barbar.state")
+local render = require('barbar.ui.render')
+local state = require('barbar.state')
 
 M.on_save = function()
   local buffers = state.export_buffers()
-  return vim.inspect(buffers, { newline = " ", indent = "" })
+  return vim.inspect(buffers, { newline = ' ', indent = '' })
 end
 
 M.on_post_load = function(data)
   if data then
-    vim.api.nvim_command("lua require('barbar.state').restore_buffers " .. data)
+    vim.api.nvim_command('lua require(\'barbar.state\').restore_buffers ' .. data)
   end
   render.update(true)
 end

--- a/lua/resession/extensions/barbar.lua
+++ b/lua/resession/extensions/barbar.lua
@@ -4,13 +4,12 @@ local state = require("barbar.state")
 
 M.on_save = function()
   local buffers = state.export_buffers()
-  return "lua require('barbar.state').restore_buffers "
-    .. vim.inspect(buffers, { newline = " ", indent = "" })
+  return vim.inspect(buffers, { newline = " ", indent = "" })
 end
 
 M.on_post_load = function(data)
   if data then
-    vim.api.nvim_command(data)
+    vim.api.nvim_command("lua require('barbar.state').restore_buffers " .. data)
   end
   render.update(true)
 end


### PR DESCRIPTION
Adds an extension for https://github.com/stevearc/resession.nvim to session save and session restore using resession. Fixes resession bug https://github.com/stevearc/resession.nvim/issues/63 and is also (imo) generally a bit nicer of a solution than using globals. Ideally this becomes the "most advisable" way of doing session management using barbar - this seems to work pretty damn flawlessly in my testing, having spent a while using persisted.nvim.

Note that the code is mostly based off of how barbar was already doing session save and session restore.