### PR TITLE
Reset highlights when `&bg` changes

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -334,6 +334,12 @@ function events.enable()
     pattern = 'buflisted',
   })
 
+  create_autocmd('OptionSet', {
+    callback = highlight.resetup,
+    group = augroup_misc,
+    pattern = 'background',
+  })
+
   create_autocmd('SessionLoadPost', {
     callback = vim.schedule_wrap(function()
       local restore_cmd = vim.g.Bufferline__session_restore

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -26,8 +26,7 @@ local win_get_width = vim.api.nvim_win_get_width --- @type function
 local api = require('barbar.api')
 local bdelete = require('barbar.bbye').bdelete
 local config = require('barbar.config')
-local highlight_reset_cache = require('barbar.utils.highlight').reset_cache
-local highlight_setup = require('barbar.highlight').setup
+local highlight = require('barbar.highlight') --- @type barbar.Highlight
 local jump_mode = require('barbar.jump_mode')
 local layout = require('barbar.ui.layout')
 local render = require('barbar.ui.render')
@@ -184,10 +183,7 @@ function events.enable()
   })
 
   create_autocmd('ColorScheme', {
-    callback = function()
-      highlight_reset_cache()
-      highlight_setup()
-    end,
+    callback = highlight.resetup,
     group = augroup_misc,
   })
 
@@ -444,7 +440,7 @@ end
 --- @return nil
 function events.on_option_changed(user_config)
   config.setup(user_config) -- NOTE: must be first `setup` called here
-  highlight_setup()
+  highlight.setup()
   jump_mode.set_letters(config.options.letters)
 
   if config.options.clickable and vim.tbl_isempty(handlers) then

--- a/lua/barbar/highlight.lua
+++ b/lua/barbar/highlight.lua
@@ -1,7 +1,7 @@
 -- !::exe [So]
 
 local config = require('barbar.config')
-local hl = require('barbar.utils.highlight')
+local hl = require('barbar.utils.highlight') --- @type barbar.utils.Hl
 local icons = require('barbar.icons')
 
 -- Setup the highlight groups used by the plugin.
@@ -311,6 +311,15 @@ function highlight.setup()
   end
 
   icons.set_highlights()
+end
+
+--- Calls resets the highlight cache and then sets up highlighting.
+---
+--- @see barbar.utils.Hl.reset_cache for details on the cache reset
+--- @see barbar.Highlight.setup for details on setting up highlights
+function highlight.resetup()
+  hl.reset_cache()
+  highlight.setup()
 end
 
 return highlight


### PR DESCRIPTION
It seems that we had an oversight in determining when the highlight
cache needed to be invalidated. We listened for the colorscheme to be
swapped, but not for mutations to the current colorscheme.

One such mutation is `set bg=dark` vs `set bg=light`. This typically
does not emit a `ColorScheme` event, but still requires us to invalidate the highlight cache and setup highlights.

To fix this, I have added an `autocmd` for `OptionSet background` which resets highlighting.

Closes #624 