### PR TITLE
fix: fs.join accepting single strings (#630)

### DIFF
--- a/lua/barbar/fs.lua
+++ b/lua/barbar/fs.lua
@@ -143,7 +143,15 @@ function fs.slice_parts_from_end(path, desired_parts)
   local parts = fs.split(path)
   parts = list.slice_from_end(parts, desired_parts)
 
-  local desired_path = fs.join(unpack(parts))
+  local unpacked = unpack(parts)
+  local desired_path
+
+  if type(unpacked) == 'string' then
+    desired_path = unpacked
+  else -- list of strings
+    desired_path = fs.join(unpacked)
+  end
+
   return desired_path
 end
 


### PR DESCRIPTION
Only joining the "unpacked" parts, if it is in fact a list. It appears that when fs.join is set to vim.fs.joinpath, fs.join will not accept single strings as input (which is the case in this function if ```desired_parts``` is 1)