### PR TITLE
fix: check that vim.fs.joinpath is not nil (#630)

### DIFF
--- a/lua/barbar/fs.lua
+++ b/lua/barbar/fs.lua
@@ -30,7 +30,7 @@ function fs.is_relative_path(path)
 end
 
 --- implementation of certain functions can be simplified based on Neovim version
-if vim.fs then
+if vim.fs and vim.fs.joinpath ~= nil then
   local normalize = vim.fs.normalize
   local join = vim.fs.joinpath
 


### PR DESCRIPTION
Check that ```vim.fs.joinpath``` is not nil before trying to reuse it, it appears that it is missing in some versions of neovim: https://vi.stackexchange.com/questions/44597/why-is-vim-fs-joinpath-missing-from-neovim-0-9-5-on-macos