### PR TITLE
remove hard-coded underlining

### DIFF
--- a/lua/barbar/highlight.lua
+++ b/lua/barbar/highlight.lua
@@ -182,7 +182,6 @@ function highlight.setup()
       hl.set('BufferDefaultAlternateSign', bg, fg_special, sp, attributes)
     else
       sp = hl.fg_or_default({'DiagnosticSignHint'}, 0xD5508F).gui
-      attributes.underline = true
 
       hl.set('BufferDefaultAlternateSign', bg, bg_tabline, sp, attributes)
       if preset == 'powerline' then
@@ -218,7 +217,6 @@ function highlight.setup()
       hl.set('BufferDefaultCurrentSign', bg, fg_special, sp, attributes)
     else
       sp = hl.sp_or_default(current_hl, 0x60AFFF)
-      attributes.underline = true
 
       hl.set('BufferDefaultCurrentSign', bg, bg_tabline, sp, attributes)
       if preset == 'powerline' then
@@ -287,7 +285,6 @@ function highlight.setup()
       hl.set('BufferDefaultVisibleSign', bg, fg, sp, attributes)
     else
       sp = hl.fg_or_default({'Delimiter'}, 0xFFFFFF).gui
-      attributes.underline = true
 
       hl.set('BufferDefaultVisibleSign', bg, bg_tabline, sp, attributes)
       if preset == 'powerline' then


### PR DESCRIPTION
how it is:
![grafik](https://github.com/user-attachments/assets/889dafd6-25ca-4684-894c-f5fb83006e6e)

how it should be:
![grafik](https://github.com/user-attachments/assets/cf41b104-3903-4cf3-8f15-088e2b435c4a)

both the slanted and powerline presets enforce underlines there.

in case you think this IS necessary, let me know, so I can change it to a configuration preset instead.