### PR TITLE
fix: use the correct modifier to remove file extensions (#639)

### DIFF
--- a/lua/barbar/buffer.lua
+++ b/lua/barbar/buffer.lua
@@ -90,7 +90,7 @@ function buffer.get_name(buffer_number, depth)
     if buf_get_option(buffer_number, 'buftype') == 'terminal' then
       full_name = terminalname(name)
     elseif hide_extensions then
-      full_name = fnamemodify(name, ':t')
+      full_name = fnamemodify(name, ':r')
     end
 
     full_name = fs.normalize(full_name)


### PR DESCRIPTION
fnamemodify was using the wrong modifier to grab the filename without the extension. This fixes that