### PR TITLE
fix: check if buffer is valid before exporting in export_buffers

### DIFF
--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -510,10 +510,12 @@ function state.export_buffers()
     local buffers = {} --- @type barbar.state.buffer.exported[]
 
     for _, bufnr in ipairs(state.buffers) do
-      table_insert(buffers, {
-        name = fs.relative(buf_get_name(bufnr)),
-        pinned = state.is_pinned(bufnr) or nil,
-      })
+      if buf_is_valid(bufnr) then
+        table_insert(buffers, {
+          name = fs.relative(buf_get_name(bufnr)),
+          pinned = state.is_pinned(bufnr) or nil,
+        })
+      end
     end
 
     return buffers


### PR DESCRIPTION
## Summary
Fixes an error where `export_buffers()` would crash with "Invalid buffer id" when trying to get the name of an invalid buffer.

## Problem
The `export_buffers()` function iterates through `state.buffers` and calls `buf_get_name(bufnr)` without checking if the buffer is still valid. This can cause a crash:
```
Error executing lua callback: .../barbar.nvim/lua/barbar/state.lua:514: Invalid buffer id: 3
stack traceback:
        [C]: in function 'buf_get_name'
        .../barbar.nvim/lua/barbar/state.lua:514: in function 'export_buffers'
```

## Solution
Added a `buf_is_valid(bufnr)` check before attempting to get the buffer name. This prevents the error by skipping invalid buffers during export.

## Test plan
- [x] Verified the fix resolves the reported error
- [x] Follows existing code patterns (similar check exists at line 346)