### PR TITLE
fix: restore diagnostics and gitsigns data after buffer list restoration

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -350,6 +350,7 @@ function events.enable()
       local restore_cmd = vim.g.Bufferline__session_restore
       if restore_cmd then command(restore_cmd) end
 
+      state.refresh_all_buffer_data()
       render.update(true)
     end),
     group = augroup_render,
@@ -382,12 +383,7 @@ function events.enable()
         local buffers = buffers_by_tab[tab]
         if buffers then
           state.restore_buffers(buffers)
-          for _, bufnr in ipairs(state.buffers) do
-            if buf_is_valid(bufnr) then
-              state.update_diagnostics(bufnr)
-              state.update_gitsigns(bufnr)
-            end
-          end
+          state.refresh_all_buffer_data()
         end
       end,
       group = augroup_misc,

--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -382,6 +382,12 @@ function events.enable()
         local buffers = buffers_by_tab[tab]
         if buffers then
           state.restore_buffers(buffers)
+          for _, bufnr in ipairs(state.buffers) do
+            if buf_is_valid(bufnr) then
+              state.update_diagnostics(bufnr)
+              state.update_gitsigns(bufnr)
+            end
+          end
         end
       end,
       group = augroup_misc,

--- a/lua/barbar/state.lua
+++ b/lua/barbar/state.lua
@@ -456,6 +456,15 @@ function state.update_gitsigns(bufnr)
   state.get_buffer_data(bufnr).gitsigns = count
 end
 
+function state.refresh_all_buffer_data()
+  for _, bufnr in ipairs(state.buffers) do
+    if buf_is_valid(bufnr) then
+      state.update_diagnostics(bufnr)
+      state.update_gitsigns(bufnr)
+    end
+  end
+end
+
 --- Update the names of all buffers in the bufferline.
 --- @return nil
 function state.update_names()

--- a/lua/resession/extensions/barbar.lua
+++ b/lua/resession/extensions/barbar.lua
@@ -11,6 +11,8 @@ M.on_post_load = function(data)
   if data then
     vim.api.nvim_command('lua require(\'barbar.state\').restore_buffers ' .. data)
   end
+
+  state.refresh_all_buffer_data()
   render.update(true)
 end
 


### PR DESCRIPTION
## Problem

When switching tabs (with scope.nvim) or restoring sessions, the diagnostics and gitsigns indicators disappear from the bufferline. This happens because `restore_buffers()` only restores buffer order and pinned state, but the `diagnostics` and `gitsigns` fields in `buffer_data` are not refreshed.

## Solution

- Add `state.refresh_all_buffer_data()` to re-fetch diagnostics and gitsigns for all buffers
- Call this function after `restore_buffers()` in:
  - `ScopeTabEnterPost` handler (scope.nvim tab switching)
  - `SessionLoadPost` handler (`:mksession` restore)
  - `resession.nvim` extension `on_post_load`

## Changes

- `lua/barbar/state.lua`: Add `refresh_all_buffer_data()` function
- `lua/barbar/events.lua`: Call refresh after session/tab restore
- `lua/resession/extensions/barbar.lua`: Call refresh after resession restore
