### PR TITLE
fix: compatibility with Neovim 0.13 which dropped BufModifiedSet

### DIFF
--- a/lua/barbar/events.lua
+++ b/lua/barbar/events.lua
@@ -36,6 +36,9 @@ local state = require('barbar.state')
 --- The `<mods>` used for the close click handler
 local CLOSE_CLICK_MODS = vim.api.nvim_cmd and { confirm = true } or 'confirm'
 
+--- Neovim 0.13 dropped BufModifiedSet in favor of OptionSet+modified
+local HAS_BUF_MODIFIED_SET = vim.fn.exists('##BufModifiedSet') == 1
+
 --- The starting index (of a buffer in `layout.buffers`) which was hovered while dragging
 --- @type nil|integer
 local drag_bufnr_start_idx = nil
@@ -141,7 +144,9 @@ end
 function events.close_click_handler(buffer)
   if buf_get_option(buffer, 'modified') then
     buf_call(buffer, function() command('w') end)
-    exec_autocmds('BufModifiedSet', {buffer = buffer})
+    if HAS_BUF_MODIFIED_SET then
+      exec_autocmds('BufModifiedSet', {buffer = buffer})
+    end
   else
     bdelete(false, buffer, CLOSE_CLICK_MODS)
   end
@@ -188,16 +193,24 @@ function events.enable()
     group = augroup_misc,
   })
 
-  create_autocmd('BufModifiedSet', {
-    callback = function(tbl)
-      local is_modified = buf_get_option(tbl.buf, 'modified')
-      if is_modified ~= vim.b[tbl.buf].checked then
-        buf_set_var(tbl.buf, 'checked', is_modified)
-        render.update()
-      end
-    end,
-    group = augroup_render,
-  })
+  if HAS_BUF_MODIFIED_SET then
+    create_autocmd('BufModifiedSet', {
+      callback = function(tbl)
+        local is_modified = buf_get_option(tbl.buf, 'modified')
+        if is_modified ~= vim.b[tbl.buf].checked then
+          buf_set_var(tbl.buf, 'checked', is_modified)
+          render.update()
+        end
+      end,
+      group = augroup_render,
+    })
+  else
+    create_autocmd('OptionSet', {
+      callback = function() render.update() end,
+      group = augroup_render,
+      pattern = 'modified',
+    })
+  end
 
   create_autocmd({'BufEnter', 'BufNew'}, {
     callback = function() render.update(true) end,


### PR DESCRIPTION
Neovim 0.13 (currently nightly) removed the `BufModifiedSet` autocmd event and replaced it with support for `OptionSet` firing on the `'modified'` option ([neovim/neovim#35610](https://github.com/neovim/neovim/pull/35610)).

The fix detects which event is available at startup using `vim.fn.exists('##BufModifiedSet')` and registers the appropriate autocmd for the running Neovim version. The `OptionSet` callback is intentionally simpler than the `BufModifiedSet` one: `OptionSet` only fires when the value actually changes, so the per-buffer checked cache that `BufModifiedSet` needed to avoid redundant renders is unnecessary. The callback reduces to an unconditional `render.update()`.

The manual `exec_autocmds('BufModifiedSet')` call in `close_click_handler` is guarded for two reasons: on 0.13 the event no longer exists and would error, and it is redundant anyway since writing the buffer triggers `OptionSet` automatically.

---

This closes #666. Unlike the alternative fix in #667, this does not introduce custom `User` autocommands and does not attempt to fix other unrelated deprecations.

Tested with currently nightly and `0.12.1`.